### PR TITLE
Allow closing role popup with Escape or double backslash

### DIFF
--- a/docs/compatibility-mode.md
+++ b/docs/compatibility-mode.md
@@ -66,7 +66,7 @@ The `backslashTrigger` function (`src/editor/backslash-trigger.ts`) creates a `V
 - **Keyboard Navigation**:
   - Arrow keys to navigate options
   - Enter to select
-  - Escape to cancel
+  - Escape or `\` to dismiss and insert a literal backslash
 - **Mouse Support**: Click to select roles
 - **Context Awareness**: Detects task code blocks and formats accordingly
 - **Proper Cleanup**: Removes event listeners on destroy
@@ -93,8 +93,9 @@ With compatibility mode enabled:
 
 1. Type `\` in the editor
 2. A popup appears with available roles
-3. Use arrow keys or mouse to select a role
-4. Press Enter or click to insert the role
-5. The role is formatted as `[🚗:: ]` or `🚗 =` depending on context
+3. Press `\` again or hit <kbd>Esc</kbd> to dismiss the popup and insert a single backslash
+4. Use arrow keys or mouse to select a role
+5. Press Enter or click to insert the role
+6. The role is formatted as `[🚗:: ]` or `🚗 =` depending on context
 
 The behavior is identical to the standard mode, just with a different interaction method.

--- a/src/editor/backslash-trigger.ts
+++ b/src/editor/backslash-trigger.ts
@@ -104,9 +104,12 @@ export function backslashTrigger(app: App, settings: TaskRolesPluginSettings) {
             const options = popup.querySelectorAll('.backslash-trigger-option');
 
             const keyHandler = (e: KeyboardEvent) => {
-                if (e.key === 'Escape') {
+                if (e.key === 'Escape' || e.key === '\\') {
+                    e.preventDefault();
                     popup.remove();
                     document.removeEventListener('keydown', keyHandler);
+                    editor.replaceRange('\\', cursor);
+                    editor.setCursor({ line: cursor.line, ch: cursor.ch + 1 });
                 } else if (e.key === 'ArrowDown') {
                     e.preventDefault();
                     options[selectedIndex].classList.remove('selected');


### PR DESCRIPTION
## Summary
- let Escape or `\` dismiss the compatibility mode popup and insert a literal backslash
- document the new behaviour in the compatibility mode guide

## Testing
- `npm run lint:ts` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d01f788ac83299b39820e11fac519