### PR TITLE
fix: add missing applyFiltersCallback parameter to CompactFiltersComponent tests

### DIFF
--- a/tests/compact-filters.test.ts
+++ b/tests/compact-filters.test.ts
@@ -30,6 +30,7 @@ describe("CompactFiltersComponent", () => {
 	let mockUpdateCallback: ReturnType<typeof vi.fn>;
 	let mockRegisterCallback: ReturnType<typeof vi.fn>;
 	let mockResetFiltersCallback: ReturnType<typeof vi.fn>;
+	let mockApplyFiltersCallback: ReturnType<typeof vi.fn>;
 	let container: HTMLElement;
 
 	beforeEach(() => {
@@ -109,13 +110,15 @@ describe("CompactFiltersComponent", () => {
 		mockUpdateCallback = vi.fn();
 		mockRegisterCallback = vi.fn();
 		mockResetFiltersCallback = vi.fn();
+		mockApplyFiltersCallback = vi.fn();
 
 		component = new CompactFiltersComponent(
 			mockPlugin as any,
 			{} as ViewFilters,
 			mockUpdateCallback,
 			mockRegisterCallback,
-			mockResetFiltersCallback
+			mockResetFiltersCallback,
+			mockApplyFiltersCallback
 		);
 	});
 
@@ -131,7 +134,8 @@ describe("CompactFiltersComponent", () => {
 				filters,
 				mockUpdateCallback,
 				mockRegisterCallback,
-				mockResetFiltersCallback
+				mockResetFiltersCallback,
+				mockApplyFiltersCallback
 			);
 
 			await component.render(container);
@@ -156,7 +160,8 @@ describe("CompactFiltersComponent", () => {
 				filters,
 				mockUpdateCallback,
 				mockRegisterCallback,
-				mockResetFiltersCallback
+				mockResetFiltersCallback,
+				mockApplyFiltersCallback
 			);
 
 			await component.render(container);
@@ -179,7 +184,8 @@ describe("CompactFiltersComponent", () => {
 				filters,
 				mockUpdateCallback,
 				mockRegisterCallback,
-				mockResetFiltersCallback
+				mockResetFiltersCallback,
+				mockApplyFiltersCallback
 			);
 
 			await component.render(container);
@@ -202,7 +208,8 @@ describe("CompactFiltersComponent", () => {
 				filters,
 				mockUpdateCallback,
 				mockRegisterCallback,
-				mockResetFiltersCallback
+				mockResetFiltersCallback,
+				mockApplyFiltersCallback
 			);
 
 			await component.render(container);
@@ -233,7 +240,8 @@ describe("CompactFiltersComponent", () => {
 				filters,
 				mockUpdateCallback,
 				mockRegisterCallback,
-				mockResetFiltersCallback
+				mockResetFiltersCallback,
+				mockApplyFiltersCallback
 			);
 
 			await component.render(container);
@@ -258,7 +266,8 @@ describe("CompactFiltersComponent", () => {
 				filters,
 				mockUpdateCallback,
 				mockRegisterCallback,
-				mockResetFiltersCallback
+				mockResetFiltersCallback,
+				mockApplyFiltersCallback
 			);
 
 			await component.render(container);


### PR DESCRIPTION
## Summary
Fixes failing test for CompactFiltersComponent clear button functionality by adding the missing `applyFiltersCallback` parameter.

## Problem
The test was failing with:
```
AssertionError: expected "spy" to be called with arguments: [ { people: [], companies: [] } ]
Number of calls: 0
```

## Root Cause
The CompactFiltersComponent constructor requires 6 parameters:
1. plugin
2. currentFilters
3. updateFiltersCallback
4. registerCallback
5. resetFiltersCallback
6. **applyFiltersCallback** ← This was missing

Tests were only passing 5 parameters, causing the component to fail during initialization and preventing the clear button from being rendered/wired up properly.

## Solution
- Added `mockApplyFiltersCallback` to the test setup
- Updated all CompactFiltersComponent instantiations to include the missing parameter

## Test Plan
- [x] Updated all test instantiations of CompactFiltersComponent
- [x] Verified the constructor signature matches test usage
- [ ] Tests should pass once CI runs

Fixes #32