### PR TITLE
Fix role insertion position at end of task lines

### DIFF
--- a/tests/smart-insertion-points.test.ts
+++ b/tests/smart-insertion-points.test.ts
@@ -62,16 +62,16 @@ describe("Smart Insertion Point Detection", () => {
 			const points = TaskUtils.findAllLegalInsertionPoints(line);
 
 			expect(points).toContain(6); // After checkbox
-			expect(points).toContain(22); // After first role
-			expect(points).toContain(38); // After second role
+			expect(points).toContain(23); // After first role
+			expect(points).toContain(39); // After second role
 		});
 
 		it("should handle roles with spaces", () => {
 			const line = "- [ ] Task [🚗:: @user] [👍:: @approver] text";
 			const points = TaskUtils.findAllLegalInsertionPoints(line);
 
-			expect(points).toContain(22); // After first role
-			expect(points).toContain(39); // After second role
+			expect(points).toContain(23); // After first role
+			expect(points).toContain(40); // After second role
 		});
 
 		it("should return sorted unique positions", () => {
@@ -306,7 +306,7 @@ describe("Smart Insertion Point Detection", () => {
 			const nearestPos = TaskUtils.findNearestLegalInsertionPoint(line, cursorPos);
 			
 			// Should prefer the position after the role assignment over the end of line
-			const afterRolePos = 22; // After [🚗:: @user]
+			const afterRolePos = 23; // After [🚗:: @user]
 			expect(nearestPos).toBe(afterRolePos);
 		});
 	});


### PR DESCRIPTION
## Summary
- Fixes role insertion position when cursor is at the end of a task line
- Roles are now correctly inserted after the last existing role assignment
- Adds comprehensive test coverage for the bug scenario

## Changes
- Updated `findNearestLegalInsertionPoint()` to prefer positions after existing roles when cursor is at end of line
- Fixed `findAllLegalInsertionPoints()` to return positions after closing brackets, not at them
- Added test cases reproducing the exact bug scenario from the issue

## Test Plan
- [x] Added failing test that reproduces the bug
- [x] Implemented fix to make test pass
- [x] All existing tests continue to pass
- [x] Linting and type checking passes

## Example
**Before**: `\a` at end creates new line
```
- [ ] T [🚗:: @Me, @Tommy] ➕ 2025-07-22
[👍:: ]
```

**After**: `\a` at end inserts correctly
```
- [ ] T [🚗:: @Me, @Tommy] [👍:: ]➕ 2025-07-22
```