### PR TITLE
fix: use addEventListener for assignee filter click handlers

### DIFF
--- a/src/components/filters/assignees-filter.ts
+++ b/src/components/filters/assignees-filter.ts
@@ -91,20 +91,20 @@ export class AssigneesFilter {
 		this.updateDisplay();
 
 		// Click on input opens the assignee selector if provided
-		this.assigneesInput.onclick = () => {
+		this.assigneesInput.addEventListener('click', () => {
 			this.showAssigneeSelector(() => {
 				this.updateDisplay();
 			});
-		};
+		});
 
 		// Clear button click event to remove assignees
-		this.clearButton.onclick = (e: MouseEvent) => {
+		this.clearButton.addEventListener('click', (e: MouseEvent) => {
 			e.stopPropagation();
 			this.callbacks.updateFilters({ people: [], companies: [] });
 			this.currentFilters.people = [];
 			this.currentFilters.companies = [];
 			this.updateDisplay();
-		};
+		});
 	}
 
 	updateDisplay(): void {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -58,7 +58,12 @@ Object.defineProperty(global, 'document', {
                 contains: vi.fn(),
                 click: vi.fn().mockImplementation(() => {
                     const clickHandlers = element._eventHandlers?.click || [];
-                    clickHandlers.forEach((handler: Function) => handler({ type: 'click', target: element }));
+                    clickHandlers.forEach((handler: Function) => handler({ 
+                        type: 'click', 
+                        target: element,
+                        stopPropagation: vi.fn(),
+                        preventDefault: vi.fn()
+                    }));
                 }),
                 querySelector: vi.fn().mockImplementation((selector: string) => {
                     // Simple implementation for class selectors

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,5 +1,9 @@
 import { defineConfig } from 'vitest/config';
-import * as path from 'path';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 export default defineConfig({
     test: {


### PR DESCRIPTION
Changed from onclick property assignment to addEventListener for both
the input click and clear button click handlers. This ensures better
compatibility with test environments where the click() method may not
trigger handlers assigned via onclick properties.