### PR TITLE
feat: add Assign role with \a shortcut

### DIFF
--- a/src/services/task-roles.service.ts
+++ b/src/services/task-roles.service.ts
@@ -255,7 +255,7 @@ export class TaskRolesService {
 			.sort((a, b) => {
 				const roleA = visibleRoles.find((r) => r.id === a.roleId);
 				const roleB = visibleRoles.find((r) => r.id === b.roleId);
-				return (roleA?.order || 999) - (roleB?.order || 999);
+				return (roleA?.order ?? 999) - (roleB?.order ?? 999);
 			});
 
 		for (const roleAssignment of sortedRoleAssignments) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -157,6 +157,14 @@ export interface ViewColumn {
 
 export const DEFAULT_ROLES: Role[] = [
 	{
+		id: "assign",
+		name: "Assign",
+		icon: "👤",
+		shortcut: "a",
+		isDefault: false,
+		order: 0,
+	},
+	{
 		id: "drivers",
 		name: "Drivers",
 		icon: "🚗",

--- a/tests/assign-role-conflict.test.ts
+++ b/tests/assign-role-conflict.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_ROLES } from '../src/types/index';
+
+describe('Assign Role Shortcut Conflict Detection', () => {
+    function isShortcutInUse(shortcut: string, excludeRoleId?: string): boolean {
+        if (!shortcut) return false;
+        return DEFAULT_ROLES.some(role => 
+            role.shortcut === shortcut && role.id !== excludeRoleId
+        );
+    }
+
+    describe('Conflict Detection Logic', () => {
+        it('should detect conflict between Assign and Approvers shortcuts', () => {
+            const assignRole = DEFAULT_ROLES.find(role => role.id === 'assign');
+            const approversRole = DEFAULT_ROLES.find(role => role.id === 'approvers');
+            
+            expect(assignRole?.shortcut).toBe('a');
+            expect(approversRole?.shortcut).toBe('a');
+            
+            // Test conflict detection function
+            expect(isShortcutInUse('a')).toBe(true);
+        });
+
+        it('should allow role to keep its own shortcut when editing', () => {
+            // When editing the Assign role, it should be allowed to keep its 'a' shortcut
+            expect(isShortcutInUse('a', 'assign')).toBe(true); // Still conflicts with Approvers
+            
+            // When editing the Approvers role, it should be allowed to keep its 'a' shortcut  
+            expect(isShortcutInUse('a', 'approvers')).toBe(true); // Still conflicts with Assign
+        });
+
+        it('should find multiple conflicts for shortcut "a"', () => {
+            const conflictingRoles = DEFAULT_ROLES.filter(role => role.shortcut === 'a');
+            expect(conflictingRoles).toHaveLength(2);
+            expect(conflictingRoles.map(r => r.id)).toContain('assign');
+            expect(conflictingRoles.map(r => r.id)).toContain('approvers');
+        });
+
+        it('should not have conflicts for other DACI shortcuts', () => {
+            // Other shortcuts should remain unique
+            expect(isShortcutInUse('d')).toBe(true); // drivers only
+            expect(isShortcutInUse('c')).toBe(true); // contributors only
+            expect(isShortcutInUse('i')).toBe(true); // informed only
+            
+            // Check no double conflicts exist for other shortcuts
+            const driverRoles = DEFAULT_ROLES.filter(role => role.shortcut === 'd');
+            const contributorRoles = DEFAULT_ROLES.filter(role => role.shortcut === 'c');
+            const informedRoles = DEFAULT_ROLES.filter(role => role.shortcut === 'i');
+            
+            expect(driverRoles).toHaveLength(1);
+            expect(contributorRoles).toHaveLength(1);
+            expect(informedRoles).toHaveLength(1);
+        });
+
+        it('should detect unused shortcuts correctly', () => {
+            expect(isShortcutInUse('x')).toBe(false);
+            expect(isShortcutInUse('z')).toBe(false);
+            expect(isShortcutInUse('')).toBe(false);
+            expect(isShortcutInUse(' ')).toBe(false);
+        });
+    });
+
+    describe('Conflict Resolution Requirements', () => {
+        it('should require user to resolve conflict when both Assign and Approvers are enabled', () => {
+            // This test verifies the requirement that users must resolve the conflict
+            const assignRole = DEFAULT_ROLES.find(role => role.id === 'assign');
+            const approversRole = DEFAULT_ROLES.find(role => role.id === 'approvers');
+            
+            // If both roles exist and both have shortcut 'a', there's a conflict
+            const hasConflict = assignRole && approversRole && 
+                               assignRole.shortcut === 'a' && 
+                               approversRole.shortcut === 'a';
+            
+            expect(hasConflict).toBe(true);
+        });
+
+        it('should validate that Assign role is disabled by default to avoid immediate conflict', () => {
+            const assignRole = DEFAULT_ROLES.find(role => role.id === 'assign');
+            const approversRole = DEFAULT_ROLES.find(role => role.id === 'approvers');
+            
+            // Assign should be disabled by default (isDefault: false)
+            // Approvers should be enabled by default (isDefault: true)
+            expect(assignRole?.isDefault).toBe(false);
+            expect(approversRole?.isDefault).toBe(true);
+            
+            // This means the conflict only becomes active when user enables Assign role
+        });
+    });
+});

--- a/tests/assign-role.test.ts
+++ b/tests/assign-role.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_ROLES } from '../src/types/index';
+
+describe('Assign Role Feature', () => {
+    describe('Role Definition', () => {
+        it('should include Assign role in DEFAULT_ROLES', () => {
+            const assignRole = DEFAULT_ROLES.find(role => role.id === 'assign');
+            expect(assignRole).toBeDefined();
+            expect(assignRole?.name).toBe('Assign');
+            expect(assignRole?.icon).toBe('👤');
+            expect(assignRole?.shortcut).toBe('a');
+            expect(assignRole?.isDefault).toBe(false); // Should be disabled by default
+            expect(assignRole?.order).toBe(0); // Should be first
+        });
+
+        it('should have Assign role as first in role order', () => {
+            const sortedRoles = [...DEFAULT_ROLES].sort((a, b) => a.order - b.order);
+            expect(sortedRoles[0].id).toBe('assign');
+            expect(sortedRoles[0].order).toBe(0);
+        });
+
+        it('should have shortcut conflict with Approvers role', () => {
+            const assignRole = DEFAULT_ROLES.find(role => role.id === 'assign');
+            const approversRole = DEFAULT_ROLES.find(role => role.id === 'approvers');
+            
+            expect(assignRole?.shortcut).toBe('a');
+            expect(approversRole?.shortcut).toBe('a');
+            // Both should have the same shortcut to test conflict detection
+        });
+    });
+
+    describe('Role Array Structure', () => {
+        it('should have correct total number of roles including Assign', () => {
+            expect(DEFAULT_ROLES).toHaveLength(5); // Original 4 DACI + 1 Assign
+        });
+
+        it('should maintain DACI roles after adding Assign', () => {
+            const daciRoleIds = ['drivers', 'approvers', 'contributors', 'informed'];
+            daciRoleIds.forEach(id => {
+                const role = DEFAULT_ROLES.find(role => role.id === id);
+                expect(role).toBeDefined();
+                expect(role?.isDefault).toBe(true);
+            });
+        });
+
+        it('should have Assign as the only non-default role', () => {
+            const nonDefaultRoles = DEFAULT_ROLES.filter(role => !role.isDefault);
+            expect(nonDefaultRoles).toHaveLength(1);
+            expect(nonDefaultRoles[0].id).toBe('assign');
+        });
+    });
+
+    describe('Role Integration', () => {
+        it('should properly sort all roles including Assign by order', () => {
+            const sortedRoles = [...DEFAULT_ROLES].sort((a, b) => a.order - b.order);
+            const expectedOrder = ['assign', 'drivers', 'approvers', 'contributors', 'informed'];
+            const actualOrder = sortedRoles.map(role => role.id);
+            expect(actualOrder).toEqual(expectedOrder);
+        });
+
+        it('should have unique IDs for all roles', () => {
+            const roleIds = DEFAULT_ROLES.map(role => role.id);
+            const uniqueIds = [...new Set(roleIds)];
+            expect(roleIds).toHaveLength(uniqueIds.length);
+        });
+
+        it('should have all required properties for Assign role', () => {
+            const assignRole = DEFAULT_ROLES.find(role => role.id === 'assign');
+            expect(assignRole).toHaveProperty('id');
+            expect(assignRole).toHaveProperty('name');
+            expect(assignRole).toHaveProperty('icon');
+            expect(assignRole).toHaveProperty('shortcut');
+            expect(assignRole).toHaveProperty('isDefault');
+            expect(assignRole).toHaveProperty('order');
+        });
+    });
+});

--- a/tests/task-assignment.service.test.ts
+++ b/tests/task-assignment.service.test.ts
@@ -13,8 +13,9 @@ describe('TaskRolesService', () => {
         const service = createService();
         const input = '[🚗:: [[People/John|@John]]]';
         const result = service.parseRoleAssignments(input, DEFAULT_ROLES);
+        const driversRole = DEFAULT_ROLES.find(role => role.id === 'drivers');
         expect(result).toEqual([
-            { role: DEFAULT_ROLES[0], assignees: ['@John'] }
+            { role: driversRole, assignees: ['@John'] }
         ]);
     });
 
@@ -32,9 +33,11 @@ describe('TaskRolesService', () => {
         const service = createService();
         const input = '[🚗:: [[People/John|@John]]] [👍:: [[People/Jane|@Jane]]]';
         const result = service.parseRoleAssignments(input, DEFAULT_ROLES);
+        const driversRole = DEFAULT_ROLES.find(role => role.id === 'drivers');
+        const approversRole = DEFAULT_ROLES.find(role => role.id === 'approvers');
         expect(result).toEqual([
-            { role: DEFAULT_ROLES[0], assignees: ['@John'] },
-            { role: DEFAULT_ROLES[1], assignees: ['@Jane'] }
+            { role: driversRole, assignees: ['@John'] },
+            { role: approversRole, assignees: ['@Jane'] }
         ]);
     });
 
@@ -65,5 +68,49 @@ describe('TaskRolesService', () => {
         expect(result).toBe(
             '- [ ] Task [👍:: [[People/Manager|@Manager]]] 📅 2024-01-01'
         );
+    });
+
+    describe('Assign Role Integration', () => {
+        it('parseRoleAssignments should handle Assign role with 👤 icon', () => {
+            const service = createService();
+            const input = '[👤:: [[People/John|@John]]]';
+            const result = service.parseRoleAssignments(input, DEFAULT_ROLES);
+            const assignRole = DEFAULT_ROLES.find(role => role.id === 'assign');
+            expect(result).toEqual([
+                { role: assignRole, assignees: ['@John'] }
+            ]);
+        });
+
+        it('applyRoleAssignmentsToLine should insert Assign role assignments', () => {
+            const service = createService();
+            const line = '- [ ] Test task 🔴 📅 2024-01-01';
+            const roleAssignments = [{ roleId: 'assign', assignees: ['@John'] }];
+            const result = service.applyRoleAssignmentsToLine(line, roleAssignments, DEFAULT_ROLES);
+            expect(result).toBe(
+                '- [ ] Test task [👤:: [[People/John|@John]]] 🔴 📅 2024-01-01'
+            );
+        });
+
+        it('formatRoleAssignments should place Assign role first due to order', () => {
+            const service = createService();
+            const roleAssignments = [
+                { roleId: 'drivers', assignees: ['@Driver'] },
+                { roleId: 'assign', assignees: ['@Assignee'] }
+            ];
+            const output = service.formatRoleAssignments(roleAssignments, DEFAULT_ROLES);
+            expect(output).toBe(
+                '[👤:: [[People/Assignee|@Assignee]]] [🚗:: [[People/Driver|@Driver]]]'
+            );
+        });
+
+        it('parseRoleAssignments should handle Assign role with multiple assignees', () => {
+            const service = createService();
+            const input = '[👤:: [[People/John|@John]], [[People/Jane|@Jane]]]';
+            const result = service.parseRoleAssignments(input, DEFAULT_ROLES);
+            const assignRole = DEFAULT_ROLES.find(role => role.id === 'assign');
+            expect(result).toEqual([
+                { role: assignRole, assignees: ['@John', '@Jane'] }
+            ]);
+        });
     });
 });


### PR DESCRIPTION
## Summary

- Adds new "Assign" role with 👤 icon and `\a` shortcut
- Places Assign role first in the role hierarchy (order: 0)
- Disabled by default unlike DACI roles (`isDefault: false`)
- Intentionally creates shortcut conflict with Approvers role (`\a`)
- Includes comprehensive test coverage following TDD approach
- Fixes nullish coalescing bug in role sorting logic that affected order 0 roles

## Key Features

### New Assign Role
The Assign role appears first in all role lists and suggestions, making it easy to quickly assign tasks to specific people or teams using the `\a` shortcut.

### Shortcut Conflict Handling
When both Assign and Approvers roles are enabled, users will encounter a shortcut conflict that requires resolution in the settings. This is intentional design to force users to choose which role should use the `\a` shortcut.

### Disabled by Default
Unlike the DACI roles (Driver, Approver, Contributor, Informed), the Assign role is disabled by default to avoid immediate shortcut conflicts.

### Bug Fix
Fixed a critical bug in role sorting where roles with `order: 0` were incorrectly treated as falsy and defaulted to order 999, causing incorrect sort order.

## Test Plan

- [x] All new Assign role tests pass
- [x] Existing role functionality remains intact
- [x] Role ordering works correctly with Assign role first
- [x] Shortcut conflict detection works as expected
- [x] Role parsing and formatting includes Assign role
- [x] TypeScript linting passes
- [x] Comprehensive test coverage added

## Breaking Changes

None. This is a pure feature addition that doesn't affect existing functionality.