### PR TITLE
refactor: remove inline styles and console logs

### DIFF
--- a/config/esbuild.config copy.mjs
+++ b/config/esbuild.config copy.mjs
@@ -46,7 +46,7 @@ const context = await esbuild.context({
 const copyStyles = () => {
     try {
         fs.copyFileSync("styles/styles.css", "styles.css");
-        console.log("✓ Copied styles.css");
+        console.info("✓ Copied styles.css");
     } catch (error) {
         console.error("Failed to copy styles.css:", error.message);
     }
@@ -57,7 +57,7 @@ const copyStyles = () => {
             const mainStyles = fs.readFileSync("styles.css", "utf8");
             const viewStyles = fs.readFileSync("styles/task-roles-view.css", "utf8");
             fs.writeFileSync("styles.css", mainStyles + "\n\n" + viewStyles);
-            console.log("✓ Merged task roles view styles");
+            console.info("✓ Merged task roles view styles");
         }
     } catch (error) {
         console.error("Failed to merge task roles view styles:", error.message);
@@ -70,7 +70,7 @@ const watchStyles = () => {
         fs.watchFile("styles/styles.css", (curr, prev) => {
             if (curr.mtime !== prev.mtime) {
                 copyStyles();
-                console.log("✓ Styles updated");
+                console.info("✓ Styles updated");
             }
         });
 
@@ -79,7 +79,7 @@ const watchStyles = () => {
             fs.watchFile("styles/task-roles-view.css", (curr, prev) => {
                 if (curr.mtime !== prev.mtime) {
                     copyStyles();
-                    console.log("✓ Task roles view styles updated");
+                    console.info("✓ Task roles view styles updated");
                 }
             });
         }

--- a/config/esbuild.config.mjs
+++ b/config/esbuild.config.mjs
@@ -46,7 +46,7 @@ const context = await esbuild.context({
 const copyStyles = () => {
     try {
         fs.copyFileSync("styles/styles.css", "styles.css");
-        console.log("✓ Copied styles.css");
+        console.info("✓ Copied styles.css");
     } catch (error) {
         console.error("Failed to copy styles.css:", error.message);
     }
@@ -57,7 +57,7 @@ const copyStyles = () => {
             const mainStyles = fs.readFileSync("styles.css", "utf8");
             const viewStyles = fs.readFileSync("styles/task-roles-view.css", "utf8");
             fs.writeFileSync("styles.css", mainStyles + "\n\n" + viewStyles);
-            console.log("✓ Merged task roles view styles");
+            console.info("✓ Merged task roles view styles");
         }
     } catch (error) {
         console.error("Failed to merge task roles view styles:", error.message);
@@ -70,7 +70,7 @@ const watchStyles = () => {
         fs.watchFile("styles/styles.css", (curr, prev) => {
             if (curr.mtime !== prev.mtime) {
                 copyStyles();
-                console.log("✓ Styles updated");
+                console.info("✓ Styles updated");
             }
         });
 
@@ -79,7 +79,7 @@ const watchStyles = () => {
             fs.watchFile("styles/task-roles-view.css", (curr, prev) => {
                 if (curr.mtime !== prev.mtime) {
                     copyStyles();
-                    console.log("✓ Task roles view styles updated");
+                    console.info("✓ Task roles view styles updated");
                 }
             });
         }

--- a/src/components/compact-filters.ts
+++ b/src/components/compact-filters.ts
@@ -183,10 +183,11 @@ export class CompactFiltersComponent {
 		});
 		const applyFiltersIcon = applyFiltersBtn.createEl("span");
 		setIcon(applyFiltersIcon, "play-circle");
-		applyFiltersBtn.title = "Apply";
-		applyFiltersBtn.style.display = this.plugin.settings.autoApplyFilters
-			? "none"
-			: "block";
+                applyFiltersBtn.title = "Apply";
+                applyFiltersBtn.classList.toggle(
+                        "task-roles-hidden",
+                        this.plugin.settings.autoApplyFilters
+                );
 		applyFiltersBtn.onclick = () => {
 			// Apply current filters
 			this.updateFiltersCallback(this.currentFilters);
@@ -206,8 +207,11 @@ export class CompactFiltersComponent {
 			await this.plugin.saveSettings();
 
 			// Show/hide buttons based on Auto Apply setting
-			const shouldHide = autoApplyCheckbox.checked;
-			applyFiltersBtn.style.display = shouldHide ? "none" : "block";
+                        const shouldHide = autoApplyCheckbox.checked;
+                        applyFiltersBtn.classList.toggle(
+                                "task-roles-hidden",
+                                shouldHide
+                        );
 
 			// If Auto Apply is enabled, apply filters immediately
 			if (autoApplyCheckbox.checked) {
@@ -245,9 +249,9 @@ export class CompactFiltersComponent {
 		cancelBtn.onclick = (e) => {
 			e.stopPropagation();
 			tempArray.length = 0;
-			tempArray.push(...originalArray);
-			dropdown.style.display = "none";
-		};
+                        tempArray.push(...originalArray);
+                        dropdown.addClass("task-roles-hidden");
+                };
 
 		const okBtn = actions.createEl("button", {
 			cls: "compact-multiselect-btn compact-multiselect-ok",
@@ -260,11 +264,11 @@ export class CompactFiltersComponent {
 	}
 
 	private setupGlobalClickHandler(allDropdowns: HTMLElement[]): void {
-		const closeAllDropdowns = () => {
-			allDropdowns.forEach((dropdown) => {
-				dropdown.style.display = "none";
-			});
-		};
+                const closeAllDropdowns = () => {
+                        allDropdowns.forEach((dropdown) => {
+                                dropdown.addClass("task-roles-hidden");
+                        });
+                };
 
 		const handleOutsideClick = (event: MouseEvent) => {
 			const target = event.target as HTMLElement;

--- a/src/components/compact-filters.ts
+++ b/src/components/compact-filters.ts
@@ -183,11 +183,11 @@ export class CompactFiltersComponent {
 		});
 		const applyFiltersIcon = applyFiltersBtn.createEl("span");
 		setIcon(applyFiltersIcon, "play-circle");
-                applyFiltersBtn.title = "Apply";
-                applyFiltersBtn.classList.toggle(
-                        "task-roles-hidden",
-                        this.plugin.settings.autoApplyFilters
-                );
+		applyFiltersBtn.title = "Apply";
+		applyFiltersBtn.classList.toggle(
+			"task-roles-hidden",
+			this.plugin.settings.autoApplyFilters
+		);
 		applyFiltersBtn.onclick = () => {
 			// Apply current filters
 			this.updateFiltersCallback(this.currentFilters);
@@ -207,11 +207,11 @@ export class CompactFiltersComponent {
 			await this.plugin.saveSettings();
 
 			// Show/hide buttons based on Auto Apply setting
-                        const shouldHide = autoApplyCheckbox.checked;
-                        applyFiltersBtn.classList.toggle(
-                                "task-roles-hidden",
-                                shouldHide
-                        );
+			const shouldHide = autoApplyCheckbox.checked;
+			applyFiltersBtn.classList.toggle(
+				"task-roles-hidden",
+				shouldHide
+			);
 
 			// If Auto Apply is enabled, apply filters immediately
 			if (autoApplyCheckbox.checked) {
@@ -249,9 +249,9 @@ export class CompactFiltersComponent {
 		cancelBtn.onclick = (e) => {
 			e.stopPropagation();
 			tempArray.length = 0;
-                        tempArray.push(...originalArray);
-                        dropdown.addClass("task-roles-hidden");
-                };
+			tempArray.push(...originalArray);
+			dropdown.addClass("task-roles-hidden");
+		};
 
 		const okBtn = actions.createEl("button", {
 			cls: "compact-multiselect-btn compact-multiselect-ok",
@@ -264,11 +264,11 @@ export class CompactFiltersComponent {
 	}
 
 	private setupGlobalClickHandler(allDropdowns: HTMLElement[]): void {
-                const closeAllDropdowns = () => {
-                        allDropdowns.forEach((dropdown) => {
-                                dropdown.addClass("task-roles-hidden");
-                        });
-                };
+		const closeAllDropdowns = () => {
+			allDropdowns.forEach((dropdown) => {
+				dropdown.addClass("task-roles-hidden");
+			});
+		};
 
 		const handleOutsideClick = (event: MouseEvent) => {
 			const target = event.target as HTMLElement;

--- a/src/components/filters/assignees-filter.ts
+++ b/src/components/filters/assignees-filter.ts
@@ -54,19 +54,17 @@ export class AssigneesFilter {
 		this.assigneesInput.readOnly = true;
 
 		// Create clear button
-		this.clearButton = inputWrapper.createEl("button", {
-			cls: "compact-filter-clear-btn",
-			title: "Clear assignees",
-		});
-		const clearIcon = this.clearButton.createEl("span", {
-			cls: "compact-filter-clear-icon",
-		});
-		setIcon(clearIcon, "x");
-		this.clearButton.style.display = "none"; // Initially hidden
+                this.clearButton = inputWrapper.createEl("button", {
+                        cls: "compact-filter-clear-btn task-roles-hidden",
+                        title: "Clear assignees",
+                });
+                const clearIcon = this.clearButton.createEl("span", {
+                        cls: "compact-filter-clear-icon",
+                });
+                setIcon(clearIcon, "x");
 
 		// Create tooltip for showing full list
-		this.tooltip = inputWrapper.createDiv("assignee-tooltip");
-		this.tooltip.style.display = "none";
+                this.tooltip = inputWrapper.createDiv("assignee-tooltip task-roles-hidden");
 
 		// Add hover events for tooltip
 		let hoverTimeout: number | null = null;
@@ -75,7 +73,7 @@ export class AssigneesFilter {
 			if (selectedAssignees.length > 3) {
 				if (hoverTimeout) clearTimeout(hoverTimeout);
 				hoverTimeout = window.setTimeout(() => {
-					this.tooltip.style.display = "block";
+                                        this.tooltip.classList.remove("task-roles-hidden");
 				}, 500);
 			}
 		});
@@ -84,7 +82,7 @@ export class AssigneesFilter {
 				clearTimeout(hoverTimeout);
 				hoverTimeout = null;
 			}
-			this.tooltip.style.display = "none";
+                        this.tooltip.classList.add("task-roles-hidden");
 		});
 
 		// Initial display update
@@ -111,18 +109,20 @@ export class AssigneesFilter {
 		const selectedAssignees = this.getSelectedAssignees();
 		if (selectedAssignees.length === 0) {
 			this.assigneesInput.value = "";
-			this.tooltip.style.display = "none";
+                        this.tooltip.classList.add("task-roles-hidden");
 		} else if (selectedAssignees.length <= 3) {
 			this.assigneesInput.value = selectedAssignees.join(", ");
-			this.tooltip.style.display = "none";
+                        this.tooltip.classList.add("task-roles-hidden");
 		} else {
 			this.assigneesInput.value = `${selectedAssignees.length} selected`;
 			this.tooltip.textContent = selectedAssignees.join(", ");
-			this.tooltip.style.display = "block";
+                        this.tooltip.classList.remove("task-roles-hidden");
 			// Tooltip visibility is controlled by hover events.
 		}
-		this.clearButton.style.display =
-			selectedAssignees.length > 0 ? "block" : "none";
+                this.clearButton.classList.toggle(
+                        "task-roles-hidden",
+                        selectedAssignees.length === 0
+                );
 	}
 
 	private getSelectedAssignees(): string[] {

--- a/src/components/filters/assignees-filter.ts
+++ b/src/components/filters/assignees-filter.ts
@@ -54,17 +54,19 @@ export class AssigneesFilter {
 		this.assigneesInput.readOnly = true;
 
 		// Create clear button
-                this.clearButton = inputWrapper.createEl("button", {
-                        cls: "compact-filter-clear-btn task-roles-hidden",
-                        title: "Clear assignees",
-                });
-                const clearIcon = this.clearButton.createEl("span", {
-                        cls: "compact-filter-clear-icon",
-                });
-                setIcon(clearIcon, "x");
+		this.clearButton = inputWrapper.createEl("button", {
+			cls: "compact-filter-clear-btn task-roles-hidden",
+			title: "Clear assignees",
+		});
+		const clearIcon = this.clearButton.createEl("span", {
+			cls: "compact-filter-clear-icon",
+		});
+		setIcon(clearIcon, "x");
 
 		// Create tooltip for showing full list
-                this.tooltip = inputWrapper.createDiv("assignee-tooltip task-roles-hidden");
+		this.tooltip = inputWrapper.createDiv(
+			"assignee-tooltip task-roles-hidden"
+		);
 
 		// Add hover events for tooltip
 		let hoverTimeout: number | null = null;
@@ -73,7 +75,7 @@ export class AssigneesFilter {
 			if (selectedAssignees.length > 3) {
 				if (hoverTimeout) clearTimeout(hoverTimeout);
 				hoverTimeout = window.setTimeout(() => {
-                                        this.tooltip.classList.remove("task-roles-hidden");
+					this.tooltip.classList.remove("task-roles-hidden");
 				}, 500);
 			}
 		});
@@ -82,21 +84,21 @@ export class AssigneesFilter {
 				clearTimeout(hoverTimeout);
 				hoverTimeout = null;
 			}
-                        this.tooltip.classList.add("task-roles-hidden");
+			this.tooltip.classList.add("task-roles-hidden");
 		});
 
 		// Initial display update
 		this.updateDisplay();
 
 		// Click on input opens the assignee selector if provided
-		this.assigneesInput.addEventListener('click', () => {
+		this.assigneesInput.addEventListener("click", () => {
 			this.showAssigneeSelector(() => {
 				this.updateDisplay();
 			});
 		});
 
 		// Clear button click event to remove assignees
-		this.clearButton.addEventListener('click', (e: MouseEvent) => {
+		this.clearButton.addEventListener("click", (e: MouseEvent) => {
 			e.stopPropagation();
 			this.callbacks.updateFilters({ people: [], companies: [] });
 			this.currentFilters.people = [];
@@ -109,20 +111,20 @@ export class AssigneesFilter {
 		const selectedAssignees = this.getSelectedAssignees();
 		if (selectedAssignees.length === 0) {
 			this.assigneesInput.value = "";
-                        this.tooltip.classList.add("task-roles-hidden");
+			this.tooltip.classList.add("task-roles-hidden");
 		} else if (selectedAssignees.length <= 3) {
 			this.assigneesInput.value = selectedAssignees.join(", ");
-                        this.tooltip.classList.add("task-roles-hidden");
+			this.tooltip.classList.add("task-roles-hidden");
 		} else {
 			this.assigneesInput.value = `${selectedAssignees.length} selected`;
 			this.tooltip.textContent = selectedAssignees.join(", ");
-                        this.tooltip.classList.remove("task-roles-hidden");
+			this.tooltip.classList.remove("task-roles-hidden");
 			// Tooltip visibility is controlled by hover events.
 		}
-                this.clearButton.classList.toggle(
-                        "task-roles-hidden",
-                        selectedAssignees.length === 0
-                );
+		this.clearButton.classList.toggle(
+			"task-roles-hidden",
+			selectedAssignees.length === 0
+		);
 	}
 
 	private getSelectedAssignees(): string[] {

--- a/src/components/filters/multi-select-filter-base.ts
+++ b/src/components/filters/multi-select-filter-base.ts
@@ -2,157 +2,161 @@ import { setIcon } from 'obsidian';
 import type TaskRolesPlugin from '../../main';
 
 export interface Option<T> {
-	value: T;
-	label: string;
-	icon?: string;
+    value: T;
+    label: string;
+    icon?: string;
 }
 
 export abstract class MultiSelectFilterBase<T> {
-	protected plugin: TaskRolesPlugin;
-	protected currentValues: T[];
-	protected updateCallback: (values: T[]) => void;
-	protected tempValues: T[];
+    protected plugin: TaskRolesPlugin;
+    protected currentValues: T[];
+    protected updateCallback: (values: T[]) => void;
+    protected tempValues: T[];
 
-	constructor(
-		plugin: TaskRolesPlugin,
-		currentValues: T[],
-		updateCallback: (values: T[]) => void
-	) {
-		this.plugin = plugin;
-		this.currentValues = currentValues;
-		this.updateCallback = updateCallback;
-		this.tempValues = [...currentValues];
-	}
+    constructor(
+        plugin: TaskRolesPlugin,
+        currentValues: T[],
+        updateCallback: (values: T[]) => void
+    ) {
+        this.plugin = plugin;
+        this.currentValues = currentValues;
+        this.updateCallback = updateCallback;
+        this.tempValues = [...currentValues];
+    }
 
-	// Render common UI: creates the container, icon, button, dropdown and event handlers.
-	render(
-		container: HTMLElement,
-		iconName: string,
-	): void {
-		const group = container.createDiv('compact-filter-group');
-		group.createEl('label', { text: '', cls: 'compact-filter-label' });
-		const iconSpan = group.createEl('span', { cls: `compact-filter-icon` });
-		setIcon(iconSpan, iconName);
+    // Render common UI: creates the container, icon, button, dropdown and event handlers.
+    render(container: HTMLElement, iconName: string): void {
+        const group = container.createDiv('compact-filter-group');
+        group.createEl('label', { text: '', cls: 'compact-filter-label' });
+        const iconSpan = group.createEl('span', { cls: 'compact-filter-icon' });
+        setIcon(iconSpan, iconName);
+
         const dropdownContainer = group.createDiv('compact-multiselect-container');
-		const displayButton = dropdownContainer.createEl('button', { cls: 'compact-multiselect-display' });
-        // Apply the white arrow to the control so CSS renders correctly.
-		this.addWhiteArrow(displayButton);
-		this.updateDisplayText(displayButton);
-		const dropdown = dropdownContainer.createDiv('compact-multiselect-dropdown'	);
-		dropdown.style.display = 'none';
+        const displayButton = dropdownContainer.createEl('button', {
+            cls: 'compact-multiselect-display',
+        });
+        this.addWhiteArrow(displayButton);
+        this.updateDisplayText(displayButton);
 
-		displayButton.onclick = (e) => {
-			e.stopPropagation();
-			const isVisible = dropdown.style.display !== 'none';
-			if (!isVisible) {
-				this.tempValues = [...this.currentValues];
-				this.renderDropdownContent(dropdown);
-			}
-			dropdown.style.display = isVisible ? 'none' : 'block';
-		};
+        const dropdown = dropdownContainer.createDiv('compact-multiselect-dropdown');
+        dropdown.classList.add('task-roles-hidden');
 
-		document.addEventListener('click', (e) => {
-			if (!group.contains(e.target as Node)) {
-				dropdown.style.display = 'none';
-			}
-		});
-	}
+        displayButton.onclick = (e) => {
+            e.stopPropagation();
+            const isVisible = !dropdown.classList.contains('task-roles-hidden');
+            if (!isVisible) {
+                this.tempValues = [...this.currentValues];
+                this.renderDropdownContent(dropdown);
+            }
+            dropdown.classList.toggle('task-roles-hidden', isVisible);
+        };
 
-	// Adds the white dropdown arrow styling to the control element.
-	protected addWhiteArrow(element: HTMLElement): void {
-		const whiteArrowSvg = `data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23ffffff' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6,9 12,15 18,9'%3E%3C/polyline%3E%3C/svg%3E`;
-		element.style.backgroundImage = `url("${whiteArrowSvg}")`;
-	}
+        document.addEventListener('click', (e) => {
+            if (!group.contains(e.target as Node)) {
+                dropdown.classList.add('task-roles-hidden');
+            }
+        });
+    }
 
-	// Renders common dropdown content and action buttons.
-	protected renderDropdownContent(dropdown: HTMLElement): void {
-		dropdown.empty();
-		const optionsContainer = dropdown.createDiv('compact-multiselect-options');
-		const options = this.getOptions();
+    // Adds the white dropdown arrow styling to the control element.
+    protected addWhiteArrow(element: HTMLElement): void {
+        element.classList.add('has-white-arrow');
+    }
 
-		// "All" option
-		const allLabel = optionsContainer.createEl('label', { cls: 'compact-multiselect-option' });
-		const allCheckbox = allLabel.createEl('input', { type: 'checkbox' });
-		allCheckbox.checked = this.tempValues.length === options.length;
-		allLabel.createSpan().setText('All');
-		allCheckbox.onchange = (e) => {
-			e.stopPropagation();
-			if ((e.target as HTMLInputElement).checked) {
-				this.tempValues = options.map(o => o.value);
-			} else {
-				this.tempValues = [];
-			}
-			this.refreshCheckboxes(optionsContainer);
-		};
+    // Renders common dropdown content and action buttons.
+    protected renderDropdownContent(dropdown: HTMLElement): void {
+        dropdown.empty();
+        const optionsContainer = dropdown.createDiv('compact-multiselect-options');
+        const options = this.getOptions();
 
-		// Individual options
-		options.forEach((option) => {
-			const optLabel = optionsContainer.createEl('label', { cls: 'compact-multiselect-option' });
-			const optCheckbox = optLabel.createEl('input', { type: 'checkbox' });
-			optCheckbox.checked = this.tempValues.includes(option.value);
-			
-			if (option.icon) {
-				// Check if icon is a character (length 1-2 for emoji) or a Lucide icon name
-				if (option.icon.length <= 2) {
-					// Character icon (emoji) - use text concatenation
-					optLabel.createSpan().setText(`${option.icon} ${option.label}`);
-				} else {
-					// Lucide icon - use setIcon()
-					const iconSpan = optLabel.createEl('span', { cls: 'compact-multiselect-option-icon' });
-					setIcon(iconSpan, option.icon);
-					optLabel.createSpan().setText(` ${option.label}`);
-				}
-			} else {
-				optLabel.createSpan().setText(option.label);
-			}
-			optCheckbox.onchange = (e) => {
-				if ((e.target as HTMLInputElement).checked) {
-					if (!this.tempValues.includes(option.value)) {
-						this.tempValues.push(option.value);
-					}
-				} else {
-					this.tempValues = this.tempValues.filter(v => v !== option.value);
-				}
-				this.refreshCheckboxes(optionsContainer);
-			};
-		});
+        // "All" option
+        const allLabel = optionsContainer.createEl('label', {
+            cls: 'compact-multiselect-option',
+        });
+        const allCheckbox = allLabel.createEl('input', { type: 'checkbox' });
+        allCheckbox.checked = this.tempValues.length === options.length;
+        allLabel.createSpan().setText('All');
+        allCheckbox.onchange = (e) => {
+            e.stopPropagation();
+            if ((e.target as HTMLInputElement).checked) {
+                this.tempValues = options.map((o) => o.value);
+            } else {
+                this.tempValues = [];
+            }
+            this.refreshCheckboxes(optionsContainer);
+        };
 
-		// Action buttons: Reset, Cancel, OK.
-		const actionsDiv = dropdown.createDiv('compact-multiselect-actions');
-		const resetBtn = actionsDiv.createEl('button', { cls: 'compact-multiselect-btn' });
-		resetBtn.setText('Reset');
-		resetBtn.onclick = (e) => {
-			e.stopPropagation();
-			this.tempValues = [];
-			this.refreshCheckboxes(optionsContainer);
-		};
-		const cancelBtn = actionsDiv.createEl('button', { cls: 'compact-multiselect-btn' });
-		cancelBtn.setText('Cancel');
-		cancelBtn.onclick = (e) => {
-			e.stopPropagation();
-			dropdown.style.display = 'none';
-		};
-		const okBtn = actionsDiv.createEl('button', { cls: 'compact-multiselect-btn compact-multiselect-ok' });
-		okBtn.setText('OK');
-		okBtn.onclick = (e) => {
-			e.stopPropagation();
-			this.currentValues = [...this.tempValues];
-			this.updateCallback(this.currentValues);
-			const btn = dropdown.parentElement?.querySelector('button');
-			if (btn) {
-				this.updateDisplayText(btn);
-			}
-			dropdown.style.display = 'none';
-		};
-	}
+        // Individual options
+        options.forEach((option) => {
+            const optLabel = optionsContainer.createEl('label', {
+                cls: 'compact-multiselect-option',
+            });
+            const optCheckbox = optLabel.createEl('input', { type: 'checkbox' });
+            optCheckbox.checked = this.tempValues.includes(option.value);
 
-	// Stub for syncing state; override if needed.
-	protected refreshCheckboxes(optionsContainer: HTMLElement): void {
-		// ...existing code...
-	}
+            if (option.icon) {
+                if (option.icon.length <= 2) {
+                    optLabel.createSpan().setText(`${option.icon} ${option.label}`);
+                } else {
+                    const iconSpan = optLabel.createEl('span', {
+                        cls: 'compact-multiselect-option-icon',
+                    });
+                    setIcon(iconSpan, option.icon);
+                    optLabel.createSpan().setText(` ${option.label}`);
+                }
+            } else {
+                optLabel.createSpan().setText(option.label);
+            }
 
-	// Must supply the options for selection.
-	protected abstract getOptions(): Option<T>[];
-	// Must update the display button text.
-	protected abstract updateDisplayText(button: HTMLElement): void;
+            optCheckbox.onchange = (e) => {
+                if ((e.target as HTMLInputElement).checked) {
+                    if (!this.tempValues.includes(option.value)) {
+                        this.tempValues.push(option.value);
+                    }
+                } else {
+                    this.tempValues = this.tempValues.filter((v) => v !== option.value);
+                }
+                this.refreshCheckboxes(optionsContainer);
+            };
+        });
+
+        const actionsDiv = dropdown.createDiv('compact-multiselect-actions');
+        const resetBtn = actionsDiv.createEl('button', { cls: 'compact-multiselect-btn' });
+        resetBtn.setText('Reset');
+        resetBtn.onclick = (e) => {
+            e.stopPropagation();
+            this.tempValues = [];
+            this.refreshCheckboxes(optionsContainer);
+        };
+
+        const cancelBtn = actionsDiv.createEl('button', { cls: 'compact-multiselect-btn' });
+        cancelBtn.setText('Cancel');
+        cancelBtn.onclick = (e) => {
+            e.stopPropagation();
+            dropdown.classList.add('task-roles-hidden');
+        };
+
+        const okBtn = actionsDiv.createEl('button', {
+            cls: 'compact-multiselect-btn compact-multiselect-ok',
+        });
+        okBtn.setText('OK');
+        okBtn.onclick = (e) => {
+            e.stopPropagation();
+            this.currentValues = [...this.tempValues];
+            this.updateCallback(this.currentValues);
+            const btn = dropdown.parentElement?.querySelector('button');
+            if (btn) {
+                this.updateDisplayText(btn);
+            }
+            dropdown.classList.add('task-roles-hidden');
+        };
+    }
+
+    protected refreshCheckboxes(_optionsContainer: HTMLElement): void {
+        // ...existing code...
+    }
+
+    protected abstract getOptions(): Option<T>[];
+    protected abstract updateDisplayText(button: HTMLElement): void;
 }
+

--- a/src/components/filters/multi-select-filter-base.ts
+++ b/src/components/filters/multi-select-filter-base.ts
@@ -1,5 +1,5 @@
-import { setIcon } from 'obsidian';
-import type TaskRolesPlugin from '../../main';
+import { setIcon } from "obsidian";
+import type TaskRolesPlugin from "../../main";
 
 export interface Option<T> {
     value: T;
@@ -26,56 +26,62 @@ export abstract class MultiSelectFilterBase<T> {
 
     // Render common UI: creates the container, icon, button, dropdown and event handlers.
     render(container: HTMLElement, iconName: string): void {
-        const group = container.createDiv('compact-filter-group');
-        group.createEl('label', { text: '', cls: 'compact-filter-label' });
-        const iconSpan = group.createEl('span', { cls: 'compact-filter-icon' });
+        const group = container.createDiv("compact-filter-group");
+        group.createEl("label", { text: "", cls: "compact-filter-label" });
+        const iconSpan = group.createEl("span", { cls: "compact-filter-icon" });
         setIcon(iconSpan, iconName);
 
-        const dropdownContainer = group.createDiv('compact-multiselect-container');
-        const displayButton = dropdownContainer.createEl('button', {
-            cls: 'compact-multiselect-display',
+        const dropdownContainer = group.createDiv(
+            "compact-multiselect-container"
+        );
+        const displayButton = dropdownContainer.createEl("button", {
+            cls: "compact-multiselect-display",
         });
         this.addWhiteArrow(displayButton);
         this.updateDisplayText(displayButton);
 
-        const dropdown = dropdownContainer.createDiv('compact-multiselect-dropdown');
-        dropdown.classList.add('task-roles-hidden');
+        const dropdown = dropdownContainer.createDiv(
+            "compact-multiselect-dropdown"
+        );
+        dropdown.classList.add("task-roles-hidden");
 
         displayButton.onclick = (e) => {
             e.stopPropagation();
-            const isVisible = !dropdown.classList.contains('task-roles-hidden');
+            const isVisible = !dropdown.classList.contains("task-roles-hidden");
             if (!isVisible) {
                 this.tempValues = [...this.currentValues];
                 this.renderDropdownContent(dropdown);
             }
-            dropdown.classList.toggle('task-roles-hidden', isVisible);
+            dropdown.classList.toggle("task-roles-hidden", isVisible);
         };
 
-        document.addEventListener('click', (e) => {
+        document.addEventListener("click", (e) => {
             if (!group.contains(e.target as Node)) {
-                dropdown.classList.add('task-roles-hidden');
+                dropdown.classList.add("task-roles-hidden");
             }
         });
     }
 
     // Adds the white dropdown arrow styling to the control element.
     protected addWhiteArrow(element: HTMLElement): void {
-        element.classList.add('has-white-arrow');
+        element.classList.add("has-white-arrow");
     }
 
     // Renders common dropdown content and action buttons.
     protected renderDropdownContent(dropdown: HTMLElement): void {
         dropdown.empty();
-        const optionsContainer = dropdown.createDiv('compact-multiselect-options');
+        const optionsContainer = dropdown.createDiv(
+            "compact-multiselect-options"
+        );
         const options = this.getOptions();
 
         // "All" option
-        const allLabel = optionsContainer.createEl('label', {
-            cls: 'compact-multiselect-option',
+        const allLabel = optionsContainer.createEl("label", {
+            cls: "compact-multiselect-option",
         });
-        const allCheckbox = allLabel.createEl('input', { type: 'checkbox' });
+        const allCheckbox = allLabel.createEl("input", { type: "checkbox" });
         allCheckbox.checked = this.tempValues.length === options.length;
-        allLabel.createSpan().setText('All');
+        allLabel.createSpan().setText("All");
         allCheckbox.onchange = (e) => {
             e.stopPropagation();
             if ((e.target as HTMLInputElement).checked) {
@@ -88,18 +94,22 @@ export abstract class MultiSelectFilterBase<T> {
 
         // Individual options
         options.forEach((option) => {
-            const optLabel = optionsContainer.createEl('label', {
-                cls: 'compact-multiselect-option',
+            const optLabel = optionsContainer.createEl("label", {
+                cls: "compact-multiselect-option",
             });
-            const optCheckbox = optLabel.createEl('input', { type: 'checkbox' });
+            const optCheckbox = optLabel.createEl("input", {
+                type: "checkbox",
+            });
             optCheckbox.checked = this.tempValues.includes(option.value);
 
             if (option.icon) {
                 if (option.icon.length <= 2) {
-                    optLabel.createSpan().setText(`${option.icon} ${option.label}`);
+                    optLabel
+                        .createSpan()
+                        .setText(`${option.icon} ${option.label}`);
                 } else {
-                    const iconSpan = optLabel.createEl('span', {
-                        cls: 'compact-multiselect-option-icon',
+                    const iconSpan = optLabel.createEl("span", {
+                        cls: "compact-multiselect-option-icon",
                     });
                     setIcon(iconSpan, option.icon);
                     optLabel.createSpan().setText(` ${option.label}`);
@@ -114,41 +124,47 @@ export abstract class MultiSelectFilterBase<T> {
                         this.tempValues.push(option.value);
                     }
                 } else {
-                    this.tempValues = this.tempValues.filter((v) => v !== option.value);
+                    this.tempValues = this.tempValues.filter(
+                        (v) => v !== option.value
+                    );
                 }
                 this.refreshCheckboxes(optionsContainer);
             };
         });
 
-        const actionsDiv = dropdown.createDiv('compact-multiselect-actions');
-        const resetBtn = actionsDiv.createEl('button', { cls: 'compact-multiselect-btn' });
-        resetBtn.setText('Reset');
+        const actionsDiv = dropdown.createDiv("compact-multiselect-actions");
+        const resetBtn = actionsDiv.createEl("button", {
+            cls: "compact-multiselect-btn",
+        });
+        resetBtn.setText("Reset");
         resetBtn.onclick = (e) => {
             e.stopPropagation();
             this.tempValues = [];
             this.refreshCheckboxes(optionsContainer);
         };
 
-        const cancelBtn = actionsDiv.createEl('button', { cls: 'compact-multiselect-btn' });
-        cancelBtn.setText('Cancel');
+        const cancelBtn = actionsDiv.createEl("button", {
+            cls: "compact-multiselect-btn",
+        });
+        cancelBtn.setText("Cancel");
         cancelBtn.onclick = (e) => {
             e.stopPropagation();
-            dropdown.classList.add('task-roles-hidden');
+            dropdown.classList.add("task-roles-hidden");
         };
 
-        const okBtn = actionsDiv.createEl('button', {
-            cls: 'compact-multiselect-btn compact-multiselect-ok',
+        const okBtn = actionsDiv.createEl("button", {
+            cls: "compact-multiselect-btn compact-multiselect-ok",
         });
-        okBtn.setText('OK');
+        okBtn.setText("OK");
         okBtn.onclick = (e) => {
             e.stopPropagation();
             this.currentValues = [...this.tempValues];
             this.updateCallback(this.currentValues);
-            const btn = dropdown.parentElement?.querySelector('button');
+            const btn = dropdown.parentElement?.querySelector("button");
             if (btn) {
                 this.updateDisplayText(btn);
             }
-            dropdown.classList.add('task-roles-hidden');
+            dropdown.classList.add("task-roles-hidden");
         };
     }
 
@@ -159,4 +175,3 @@ export abstract class MultiSelectFilterBase<T> {
     protected abstract getOptions(): Option<T>[];
     protected abstract updateDisplayText(button: HTMLElement): void;
 }
-

--- a/src/components/role-suggestion-dropdown.ts
+++ b/src/components/role-suggestion-dropdown.ts
@@ -8,11 +8,13 @@ export class RoleSuggestionDropdown {
 	private dropdownElement: HTMLElement | null = null;
 	private isVisible = false;
 	private availableRoles: Role[] = [];
-	private selectedIndex = 0;
-	private currentFilter = "";
-	private triggerPos: { line: number; ch: number } | null = null;
-	private onInsertCallback: ((role: Role) => void) | null = null;
-	private autoHideTimeout: number | null = null;
+        private selectedIndex = 0;
+        private currentFilter = "";
+        private triggerPos: { line: number; ch: number } | null = null;
+        private onInsertCallback: ((role: Role) => void) | null = null;
+        private autoHideTimeout: number | null = null;
+        private dropdownLeft = 0;
+        private dropdownTop = 0;
 
 	constructor(app: App, settings: TaskRolesPluginSettings, getVisibleRoles: () => Role[]) {
 		this.app = app;
@@ -291,8 +293,16 @@ export class RoleSuggestionDropdown {
 		const maxLeft = window.innerWidth - dropdownRect.width - 20;
 		const maxTop = window.innerHeight - dropdownRect.height - 20;
 
-		this.dropdownElement.style.left = Math.min(left, maxLeft) + "px";
-		this.dropdownElement.style.top = Math.min(top, maxTop) + "px";
+                this.dropdownLeft = Math.min(left, maxLeft);
+                this.dropdownTop = Math.min(top, maxTop);
+                this.dropdownElement.style.setProperty(
+                        "--task-roles-dropdown-left",
+                        `${this.dropdownLeft}px`
+                );
+                this.dropdownElement.style.setProperty(
+                        "--task-roles-dropdown-top",
+                        `${this.dropdownTop}px`
+                );
 
 		// Check if dropdown is covered by other elements
 		this.checkForCoverage();
@@ -311,15 +321,22 @@ export class RoleSuggestionDropdown {
 
 			// Loop 10 times adding 30px to left position
 			for (let i = 0; i < 10; i++) {
-				const newLeft = parseInt(this.dropdownElement.style.left) + 30;
-				this.dropdownElement.style.left = newLeft + "px";
+                                const newLeft = this.dropdownLeft + 30;
+                                this.dropdownLeft = newLeft;
+                                this.dropdownElement.style.setProperty(
+                                        "--task-roles-dropdown-left",
+                                        `${this.dropdownLeft}px`
+                                );
 
 				if (!this.isCovered(this.dropdownElement)) {
 					if (this.settings.debug) {
-						console.warn("Adjusted position to avoid coverage:", {
-							left: this.dropdownElement.style.left,
-							top: this.dropdownElement.style.top,
-						});
+                                                console.warn(
+                                                        "Adjusted position to avoid coverage:",
+                                                        {
+                                                                left: `${this.dropdownLeft}px`,
+                                                                top: `${this.dropdownTop}px`,
+                                                        }
+                                                );
 					}
 					break;
 				}

--- a/src/components/role-suggestion-dropdown.ts
+++ b/src/components/role-suggestion-dropdown.ts
@@ -8,13 +8,13 @@ export class RoleSuggestionDropdown {
 	private dropdownElement: HTMLElement | null = null;
 	private isVisible = false;
 	private availableRoles: Role[] = [];
-        private selectedIndex = 0;
-        private currentFilter = "";
-        private triggerPos: { line: number; ch: number } | null = null;
-        private onInsertCallback: ((role: Role) => void) | null = null;
-        private autoHideTimeout: number | null = null;
-        private dropdownLeft = 0;
-        private dropdownTop = 0;
+	private selectedIndex = 0;
+	private currentFilter = "";
+	private triggerPos: { line: number; ch: number } | null = null;
+	private onInsertCallback: ((role: Role) => void) | null = null;
+	private autoHideTimeout: number | null = null;
+	private dropdownLeft = 0;
+	private dropdownTop = 0;
 
 	constructor(app: App, settings: TaskRolesPluginSettings, getVisibleRoles: () => Role[]) {
 		this.app = app;
@@ -163,19 +163,19 @@ export class RoleSuggestionDropdown {
 		return false;
 	}
 
-    private updateFilter(filter: string): void {
-        this.currentFilter = filter;
+	private updateFilter(filter: string): void {
+		this.currentFilter = filter;
 
-        if (filter === "") {
-            // Show all available roles when filter is empty
-            this.availableRoles = this.getAvailableRoles([]);
-        } else {
-            // Filter roles by name
-            const allRoles = this.getAvailableRoles([]);
-            const fl = filter.toLowerCase();
-            const filteredRoles = allRoles.filter((role) =>
-                (role.names || []).some((n) => n.toLowerCase().startsWith(fl))
-            );
+		if (filter === "") {
+			// Show all available roles when filter is empty
+			this.availableRoles = this.getAvailableRoles([]);
+		} else {
+			// Filter roles by name
+			const allRoles = this.getAvailableRoles([]);
+			const fl = filter.toLowerCase();
+			const filteredRoles = allRoles.filter((role) =>
+				(role.names || []).some((n) => n.toLowerCase().startsWith(fl))
+			);
 
 			// If no matches, show all roles (as specified in requirements)
 			this.availableRoles =
@@ -293,16 +293,16 @@ export class RoleSuggestionDropdown {
 		const maxLeft = window.innerWidth - dropdownRect.width - 20;
 		const maxTop = window.innerHeight - dropdownRect.height - 20;
 
-                this.dropdownLeft = Math.min(left, maxLeft);
-                this.dropdownTop = Math.min(top, maxTop);
-                this.dropdownElement.style.setProperty(
-                        "--task-roles-dropdown-left",
-                        `${this.dropdownLeft}px`
-                );
-                this.dropdownElement.style.setProperty(
-                        "--task-roles-dropdown-top",
-                        `${this.dropdownTop}px`
-                );
+		this.dropdownLeft = Math.min(left, maxLeft);
+		this.dropdownTop = Math.min(top, maxTop);
+		this.dropdownElement.style.setProperty(
+			"--task-roles-dropdown-left",
+			`${this.dropdownLeft}px`
+		);
+		this.dropdownElement.style.setProperty(
+			"--task-roles-dropdown-top",
+			`${this.dropdownTop}px`
+		);
 
 		// Check if dropdown is covered by other elements
 		this.checkForCoverage();
@@ -321,22 +321,22 @@ export class RoleSuggestionDropdown {
 
 			// Loop 10 times adding 30px to left position
 			for (let i = 0; i < 10; i++) {
-                                const newLeft = this.dropdownLeft + 30;
-                                this.dropdownLeft = newLeft;
-                                this.dropdownElement.style.setProperty(
-                                        "--task-roles-dropdown-left",
-                                        `${this.dropdownLeft}px`
-                                );
+				const newLeft = this.dropdownLeft + 30;
+				this.dropdownLeft = newLeft;
+				this.dropdownElement.style.setProperty(
+					"--task-roles-dropdown-left",
+					`${this.dropdownLeft}px`
+				);
 
 				if (!this.isCovered(this.dropdownElement)) {
 					if (this.settings.debug) {
-                                                console.warn(
-                                                        "Adjusted position to avoid coverage:",
-                                                        {
-                                                                left: `${this.dropdownLeft}px`,
-                                                                top: `${this.dropdownTop}px`,
-                                                        }
-                                                );
+						console.warn(
+							"Adjusted position to avoid coverage:",
+							{
+								left: `${this.dropdownLeft}px`,
+								top: `${this.dropdownTop}px`,
+							}
+						);
 					}
 					break;
 				}
@@ -352,9 +352,9 @@ export class RoleSuggestionDropdown {
 			this.dropdownElement.removeChild(this.dropdownElement.firstChild);
 		}
 
-        this.availableRoles.forEach((role, index) => {
-            const item = document.createElement("div");
-            item.className = "task-roles-suggestion-item";
+		this.availableRoles.forEach((role, index) => {
+			const item = document.createElement("div");
+			item.className = "task-roles-suggestion-item";
 
 			// Create role icon span
 			const iconSpan = document.createElement("span");
@@ -362,33 +362,33 @@ export class RoleSuggestionDropdown {
 			iconSpan.textContent = role.icon;
 			item.appendChild(iconSpan);
 
-            // Create role name span with highlighting support
-            const nameSpan = document.createElement("span");
-            nameSpan.className = "role-name";
-            const primaryName = (role.names?.[0] || "");
-            const displayName = primaryName
-                ? primaryName.charAt(0).toUpperCase() + primaryName.slice(1)
-                : "";
+			// Create role name span with highlighting support
+			const nameSpan = document.createElement("span");
+			nameSpan.className = "role-name";
+			const primaryName = (role.names?.[0] || "");
+			const displayName = primaryName
+				? primaryName.charAt(0).toUpperCase() + primaryName.slice(1)
+				: "";
 
-            if (this.currentFilter) {
-                // Handle highlighting by splitting the text and creating mark elements
-                const regex = new RegExp(`(${this.currentFilter})`, "gi");
-                const parts = displayName.split(regex);
+			if (this.currentFilter) {
+				// Handle highlighting by splitting the text and creating mark elements
+				const regex = new RegExp(`(${this.currentFilter})`, "gi");
+				const parts = displayName.split(regex);
 
-                parts.forEach((part, partIndex) => {
-                    if (part.toLowerCase() === this.currentFilter.toLowerCase()) {
-                        const mark = document.createElement("mark");
-                        mark.textContent = part;
-                        nameSpan.appendChild(mark);
-                    } else if (part) {
-                        const textNode = document.createTextNode(part);
-                        nameSpan.appendChild(textNode);
-                    }
-                });
-            } else {
-                nameSpan.textContent = displayName;
-            }
-            item.appendChild(nameSpan);
+				parts.forEach((part, partIndex) => {
+					if (part.toLowerCase() === this.currentFilter.toLowerCase()) {
+						const mark = document.createElement("mark");
+						mark.textContent = part;
+						nameSpan.appendChild(mark);
+					} else if (part) {
+						const textNode = document.createTextNode(part);
+						nameSpan.appendChild(textNode);
+					}
+				});
+			} else {
+				nameSpan.textContent = displayName;
+			}
+			item.appendChild(nameSpan);
 
 			// Set selected class if this is the selected index
 			if (index === this.selectedIndex) {

--- a/src/modals/person-company-picker-modal.ts
+++ b/src/modals/person-company-picker-modal.ts
@@ -179,16 +179,16 @@ export class PersonCompanyPickerModal extends FuzzySuggestModal<string> {
 			return;
 		}
 
-		if (this.plugin.settings.debug) {
-			console.log(
-				"No suggestions for input: ",
-				this.inputEl.value,
-				" with query: ",
-				query,
-				" and query length ",
-				query.length
-			);
-		}
+                if (this.plugin.settings.debug) {
+                        console.debug(
+                                "No suggestions for input: ",
+                                this.inputEl.value,
+                                " with query: ",
+                                query,
+                                " and query length ",
+                                query.length
+                        );
+                }
 		if (
 			!query.startsWith(this.plugin.settings.personSymbol) &&
 			!query.startsWith(this.plugin.settings.companySymbol)
@@ -202,14 +202,14 @@ export class PersonCompanyPickerModal extends FuzzySuggestModal<string> {
 			return;
 		}
 
-		if (this.plugin.settings.debug) {
-			console.log(
-				"No results, setting noResults to true for ",
-				this.inputEl.value,
-				" with query ",
-				query
-			);
-		}
+                if (this.plugin.settings.debug) {
+                        console.debug(
+                                "No results, setting noResults to true for ",
+                                this.inputEl.value,
+                                " with query ",
+                                query
+                        );
+                }
 		this.noResults = true;
 
 		// In add mode, show creation hint

--- a/src/modals/person-company-picker-modal.ts
+++ b/src/modals/person-company-picker-modal.ts
@@ -179,16 +179,16 @@ export class PersonCompanyPickerModal extends FuzzySuggestModal<string> {
 			return;
 		}
 
-                if (this.plugin.settings.debug) {
-                        console.debug(
-                                "No suggestions for input: ",
-                                this.inputEl.value,
-                                " with query: ",
-                                query,
-                                " and query length ",
-                                query.length
-                        );
-                }
+		if (this.plugin.settings.debug) {
+			console.debug(
+				"No suggestions for input: ",
+				this.inputEl.value,
+				" with query: ",
+				query,
+				" and query length ",
+				query.length
+			);
+		}
 		if (
 			!query.startsWith(this.plugin.settings.personSymbol) &&
 			!query.startsWith(this.plugin.settings.companySymbol)
@@ -202,14 +202,14 @@ export class PersonCompanyPickerModal extends FuzzySuggestModal<string> {
 			return;
 		}
 
-                if (this.plugin.settings.debug) {
-                        console.debug(
-                                "No results, setting noResults to true for ",
-                                this.inputEl.value,
-                                " with query ",
-                                query
-                        );
-                }
+		if (this.plugin.settings.debug) {
+			console.debug(
+				"No results, setting noResults to true for ",
+				this.inputEl.value,
+				" with query ",
+				query
+			);
+		}
 		this.noResults = true;
 
 		// In add mode, show creation hint

--- a/src/modals/save-view-modal.ts
+++ b/src/modals/save-view-modal.ts
@@ -64,12 +64,12 @@ export class TaskRolesSaveViewModal extends Modal {
             });
 
         // Overwrite warning (initially hidden)
-        const overwriteWarning = contentEl.createDiv('overwrite-warning');
-        overwriteWarning.style.display = 'none';
-        overwriteWarning.style.color = 'var(--text-warning)';
-        overwriteWarning.style.marginTop = '8px';
-        overwriteWarning.style.fontSize = '14px';
-        overwriteWarning.setText('⚠️ This will overwrite an existing configuration with the same name.');
+        const overwriteWarning = contentEl.createDiv(
+            'overwrite-warning task-roles-hidden'
+        );
+        overwriteWarning.setText(
+            '⚠️ This will overwrite an existing configuration with the same name.'
+        );
 
         // Show current configuration summary
         const summaryEl = contentEl.createDiv('view-config-summary');
@@ -190,7 +190,7 @@ export class TaskRolesSaveViewModal extends Modal {
     private updateOverwriteWarning(exists: boolean): void {
         const warning = this.contentEl.querySelector('.overwrite-warning') as HTMLElement;
         if (warning) {
-            warning.style.display = exists ? 'block' : 'none';
+            warning.toggleClass('task-roles-hidden', !exists);
         }
     }
 
@@ -204,8 +204,5 @@ export class TaskRolesSaveViewModal extends Modal {
         // Show new error
         const error = this.contentEl.createDiv('view-name-error');
         error.setText(message);
-        error.style.color = 'var(--text-error)';
-        error.style.marginTop = '8px';
-        error.style.fontSize = '14px';
     }
 } 

--- a/src/services/task-query.service.ts
+++ b/src/services/task-query.service.ts
@@ -13,64 +13,68 @@ export class TaskQueryService {
 		// Check if the Tasks plugin is installed and enabled
 		const pluginManager = (this.plugin.app as any).plugins;
 		const tasksPluginName = "obsidian-tasks-plugin";
-                const isInstalled = tasksPluginName in pluginManager.manifests;
-                if (this.plugin.settings.debug)
-                        console.debug(pluginManager.manifests, tasksPluginName, isInstalled);
+		const isInstalled = tasksPluginName in pluginManager.manifests;
+		if (this.plugin.settings.debug)
+			console.debug(
+				pluginManager.manifests,
+				tasksPluginName,
+				isInstalled
+			);
 		const isEnabled = pluginManager.enabledPlugins.has(tasksPluginName);
 		const targetInstance = pluginManager.getPlugin(tasksPluginName);
 		const isLoaded = targetInstance !== undefined;
 		return isInstalled && isEnabled && isLoaded;
 	}
 
-        private displayTasksPluginNotice(
-                columnDiv: HTMLElement,
-                onRefresh?: () => void
-        ): void {
-                const noticeDiv = columnDiv.createDiv("tasks-plugin-notice");
+	private displayTasksPluginNotice(
+		columnDiv: HTMLElement,
+		onRefresh?: () => void
+	): void {
+		const noticeDiv = columnDiv.createDiv("tasks-plugin-notice");
 
-                // Warning icon
-                const iconDiv = noticeDiv.createDiv("tasks-plugin-notice-icon");
-                const iconSpan = iconDiv.createSpan("tasks-plugin-notice-icon-span");
-                setIcon(iconSpan, "alert-triangle");
+		// Warning icon
+		const iconDiv = noticeDiv.createDiv("tasks-plugin-notice-icon");
+		const iconSpan = iconDiv.createSpan("tasks-plugin-notice-icon-span");
+		setIcon(iconSpan, "alert-triangle");
 
-                // Notice text
-                const textDiv = noticeDiv.createDiv("tasks-plugin-notice-text");
+		// Notice text
+		const textDiv = noticeDiv.createDiv("tasks-plugin-notice-text");
 
-                const titleEl = textDiv.createEl("div", {
-                        cls: "tasks-plugin-notice-title",
-                });
-                titleEl.textContent = "Tasks Plugin Required";
+		const titleEl = textDiv.createEl("div", {
+			cls: "tasks-plugin-notice-title",
+		});
+		titleEl.textContent = "Tasks Plugin Required";
 
-                const descEl = textDiv.createEl("div", {
-                        cls: "tasks-plugin-notice-desc",
-                });
-                descEl.textContent =
-                        "The Task Center requires the Tasks plugin to be installed and enabled to display task columns.";
+		const descEl = textDiv.createEl("div", {
+			cls: "tasks-plugin-notice-desc",
+		});
+		descEl.textContent =
+			"The Task Center requires the Tasks plugin to be installed and enabled to display task columns.";
 
-                // Instructions
-                const instructionsEl = textDiv.createEl("div", {
-                        cls: "tasks-plugin-notice-instructions",
-                });
+		// Instructions
+		const instructionsEl = textDiv.createEl("div", {
+			cls: "tasks-plugin-notice-instructions",
+		});
 
-                // Create instruction text using DOM API instead of innerHTML
-                instructionsEl.appendChild(document.createTextNode("Install the "));
-                const strongEl = instructionsEl.createEl("strong");
-                strongEl.textContent = "Tasks";
-                instructionsEl.appendChild(
-                        document.createTextNode(
-                                " plugin from Community Plugins and enable it to use this feature."
-                        )
-                );
+		// Create instruction text using DOM API instead of innerHTML
+		instructionsEl.appendChild(document.createTextNode("Install the "));
+		const strongEl = instructionsEl.createEl("strong");
+		strongEl.textContent = "Tasks";
+		instructionsEl.appendChild(
+			document.createTextNode(
+				" plugin from Community Plugins and enable it to use this feature."
+			)
+		);
 
-                // Refresh button if callback provided
-                if (onRefresh) {
-                        const refreshButton = noticeDiv.createEl("button", {
-                                cls: "mod-cta tasks-plugin-notice-refresh",
-                        });
-                        refreshButton.textContent = "Check Again";
-                        refreshButton.onclick = onRefresh;
-                }
-        }
+		// Refresh button if callback provided
+		if (onRefresh) {
+			const refreshButton = noticeDiv.createEl("button", {
+				cls: "mod-cta tasks-plugin-notice-refresh",
+			});
+			refreshButton.textContent = "Check Again";
+			refreshButton.onclick = onRefresh;
+		}
+	}
 
 	buildTaskQueryFromFilters(filters: ViewFilters): string {
 		const queryLines: string[] = [];
@@ -310,19 +314,21 @@ export class TaskQueryService {
 		switch (layout) {
 			case ViewLayout.ROLE:
 				const visibleRoles = this.plugin.getVisibleRoles();
-                for (const role of visibleRoles) {
-                    const roleQuery = baseQuery
-                        ? `${baseQuery}\ndescription includes ${role.icon}`
-                        : `description includes ${role.icon}`;
-                    const primary = role.names?.[0] || "";
-                    const display = primary ? primary.charAt(0).toUpperCase() + primary.slice(1) : "";
-                    columnQueries.push({
-                        title: display,
-                        query: roleQuery,
-                        icon: role.icon,
-                        isEmoji: true,
-                    });
-                }
+				for (const role of visibleRoles) {
+					const roleQuery = baseQuery
+						? `${baseQuery}\ndescription includes ${role.icon}`
+						: `description includes ${role.icon}`;
+					const primary = role.names?.[0] || "";
+					const display = primary
+						? primary.charAt(0).toUpperCase() + primary.slice(1)
+						: "";
+					columnQueries.push({
+						title: display,
+						query: roleQuery,
+						icon: role.icon,
+						isEmoji: true,
+					});
+				}
 				// Add "No Role" column
 				const noRoleConditions = visibleRoles.map(
 					(role) => `description does not include ${role.icon}`
@@ -480,18 +486,18 @@ export class TaskQueryService {
 		if (columnQuery.icon) {
 			if (columnQuery.isEmoji) {
 				// Use emoji icon
-                                const emojiIcon = titleEl.createSpan("column-icon-emoji");
-                                emojiIcon.setText(columnQuery.icon);
-                        } else {
-                                // Use Obsidian system icon
-                                const iconSpan = titleEl.createSpan("column-icon");
-                                setIcon(iconSpan, columnQuery.icon);
-                        }
-                }
+				const emojiIcon = titleEl.createSpan("column-icon-emoji");
+				emojiIcon.setText(columnQuery.icon);
+			} else {
+				// Use Obsidian system icon
+				const iconSpan = titleEl.createSpan("column-icon");
+				setIcon(iconSpan, columnQuery.icon);
+			}
+		}
 
-                // Add title text
-                const titleText = titleEl.createSpan("column-title-text");
-                titleText.setText(columnQuery.title);
+		// Add title text
+		const titleText = titleEl.createSpan("column-title-text");
+		titleText.setText(columnQuery.title);
 
 		// Check if Tasks plugin is installed before rendering content
 		if (!this.isTasksPluginInstalled()) {
@@ -782,19 +788,19 @@ export class TaskQueryService {
 		const metadata = taskItem.querySelector(".task-metadata");
 		if (!metadata) return;
 
-                // Add hover handlers for minimal mode
-                taskItem.addEventListener("mouseenter", () => {
-                        if (taskItem.closest(".tasks-styled--minimal")) {
-                                (metadata as HTMLElement).addClass("task-metadata-visible");
-                        }
-                });
+		// Add hover handlers for minimal mode
+		taskItem.addEventListener("mouseenter", () => {
+			if (taskItem.closest(".tasks-styled--minimal")) {
+				(metadata as HTMLElement).addClass("task-metadata-visible");
+			}
+		});
 
-                taskItem.addEventListener("mouseleave", () => {
-                        if (taskItem.closest(".tasks-styled--minimal")) {
-                                (metadata as HTMLElement).removeClass("task-metadata-visible");
-                        }
-                });
-        }
+		taskItem.addEventListener("mouseleave", () => {
+			if (taskItem.closest(".tasks-styled--minimal")) {
+				(metadata as HTMLElement).removeClass("task-metadata-visible");
+			}
+		});
+	}
 
 	private buildCrossProductQuery(
 		filters: ViewFilters,

--- a/src/services/task-query.service.ts
+++ b/src/services/task-query.service.ts
@@ -13,80 +13,64 @@ export class TaskQueryService {
 		// Check if the Tasks plugin is installed and enabled
 		const pluginManager = (this.plugin.app as any).plugins;
 		const tasksPluginName = "obsidian-tasks-plugin";
-		const isInstalled = tasksPluginName in pluginManager.manifests;
-		if (this.plugin.settings.debug)
-			console.log(pluginManager.manifests, tasksPluginName, isInstalled);
+                const isInstalled = tasksPluginName in pluginManager.manifests;
+                if (this.plugin.settings.debug)
+                        console.debug(pluginManager.manifests, tasksPluginName, isInstalled);
 		const isEnabled = pluginManager.enabledPlugins.has(tasksPluginName);
 		const targetInstance = pluginManager.getPlugin(tasksPluginName);
 		const isLoaded = targetInstance !== undefined;
 		return isInstalled && isEnabled && isLoaded;
 	}
 
-	private displayTasksPluginNotice(
-		columnDiv: HTMLElement,
-		onRefresh?: () => void
-	): void {
-		const noticeDiv = columnDiv.createDiv("tasks-plugin-notice");
-		noticeDiv.style.padding = "20px";
-		noticeDiv.style.textAlign = "center";
-		noticeDiv.style.color = "var(--text-muted)";
-		noticeDiv.style.border = "2px dashed var(--background-modifier-border)";
-		noticeDiv.style.borderRadius = "8px";
-		noticeDiv.style.margin = "10px 0";
-		noticeDiv.style.backgroundColor = "var(--background-secondary)";
+        private displayTasksPluginNotice(
+                columnDiv: HTMLElement,
+                onRefresh?: () => void
+        ): void {
+                const noticeDiv = columnDiv.createDiv("tasks-plugin-notice");
 
-		// Warning icon
-		const iconDiv = noticeDiv.createDiv();
-		iconDiv.style.marginBottom = "10px";
-		const iconSpan = iconDiv.createSpan();
-		setIcon(iconSpan, "alert-triangle");
-		iconSpan.style.width = "24px";
-		iconSpan.style.height = "24px";
-		iconSpan.style.color = "var(--text-warning)";
+                // Warning icon
+                const iconDiv = noticeDiv.createDiv("tasks-plugin-notice-icon");
+                const iconSpan = iconDiv.createSpan("tasks-plugin-notice-icon-span");
+                setIcon(iconSpan, "alert-triangle");
 
-		// Notice text
-		const textDiv = noticeDiv.createDiv();
-		textDiv.style.fontSize = "14px";
-		textDiv.style.lineHeight = "1.4";
+                // Notice text
+                const textDiv = noticeDiv.createDiv("tasks-plugin-notice-text");
 
-		const titleEl = textDiv.createEl("div");
-		titleEl.style.fontWeight = "bold";
-		titleEl.style.marginBottom = "8px";
-		titleEl.style.color = "var(--text-normal)";
-		titleEl.textContent = "Tasks Plugin Required";
+                const titleEl = textDiv.createEl("div", {
+                        cls: "tasks-plugin-notice-title",
+                });
+                titleEl.textContent = "Tasks Plugin Required";
 
-		const descEl = textDiv.createEl("div");
-		descEl.style.marginBottom = "12px";
-		descEl.textContent =
-			"The Task Center requires the Tasks plugin to be installed and enabled to display task columns.";
+                const descEl = textDiv.createEl("div", {
+                        cls: "tasks-plugin-notice-desc",
+                });
+                descEl.textContent =
+                        "The Task Center requires the Tasks plugin to be installed and enabled to display task columns.";
 
-		// Instructions
-		const instructionsEl = textDiv.createEl("div");
-		instructionsEl.style.fontSize = "12px";
-		instructionsEl.style.color = "var(--text-muted)";
-		instructionsEl.style.marginBottom = "15px";
+                // Instructions
+                const instructionsEl = textDiv.createEl("div", {
+                        cls: "tasks-plugin-notice-instructions",
+                });
 
-		// Create instruction text using DOM API instead of innerHTML
-		instructionsEl.appendChild(document.createTextNode("Install the "));
-		const strongEl = instructionsEl.createEl("strong");
-		strongEl.textContent = "Tasks";
-		instructionsEl.appendChild(
-			document.createTextNode(
-				" plugin from Community Plugins and enable it to use this feature."
-			)
-		);
+                // Create instruction text using DOM API instead of innerHTML
+                instructionsEl.appendChild(document.createTextNode("Install the "));
+                const strongEl = instructionsEl.createEl("strong");
+                strongEl.textContent = "Tasks";
+                instructionsEl.appendChild(
+                        document.createTextNode(
+                                " plugin from Community Plugins and enable it to use this feature."
+                        )
+                );
 
-		// Refresh button if callback provided
-		if (onRefresh) {
-			const refreshButton = noticeDiv.createEl("button", {
-				cls: "mod-cta",
-			});
-			refreshButton.textContent = "Check Again";
-			refreshButton.style.marginTop = "10px";
-			refreshButton.style.padding = "6px 12px";
-			refreshButton.onclick = onRefresh;
-		}
-	}
+                // Refresh button if callback provided
+                if (onRefresh) {
+                        const refreshButton = noticeDiv.createEl("button", {
+                                cls: "mod-cta tasks-plugin-notice-refresh",
+                        });
+                        refreshButton.textContent = "Check Again";
+                        refreshButton.onclick = onRefresh;
+                }
+        }
 
 	buildTaskQueryFromFilters(filters: ViewFilters): string {
 		const queryLines: string[] = [];
@@ -496,34 +480,18 @@ export class TaskQueryService {
 		if (columnQuery.icon) {
 			if (columnQuery.isEmoji) {
 				// Use emoji icon
-				const emojiIcon = titleEl.createSpan("column-icon-emoji");
-				emojiIcon.setText(columnQuery.icon);
-				emojiIcon.style.marginRight = "8px";
-				emojiIcon.style.fontSize = "16px";
-				emojiIcon.style.lineHeight = "1";
-				emojiIcon.style.verticalAlign = "middle";
-			} else {
-				// Use Obsidian system icon
-				const iconSpan = titleEl.createSpan("column-icon");
-				setIcon(iconSpan, columnQuery.icon);
-				iconSpan.style.marginRight = "8px";
-				iconSpan.style.display = "inline-flex";
-				iconSpan.style.alignItems = "center";
-				iconSpan.style.verticalAlign = "middle";
-				iconSpan.style.width = "16px";
-				iconSpan.style.height = "16px";
-			}
-		}
+                                const emojiIcon = titleEl.createSpan("column-icon-emoji");
+                                emojiIcon.setText(columnQuery.icon);
+                        } else {
+                                // Use Obsidian system icon
+                                const iconSpan = titleEl.createSpan("column-icon");
+                                setIcon(iconSpan, columnQuery.icon);
+                        }
+                }
 
-		// Add title text
-		const titleText = titleEl.createSpan("column-title-text");
-		titleText.setText(columnQuery.title);
-		titleText.style.verticalAlign = "middle";
-
-		// Style the title element for better alignment
-		titleEl.style.display = "flex";
-		titleEl.style.alignItems = "center";
-		titleEl.style.gap = "0";
+                // Add title text
+                const titleText = titleEl.createSpan("column-title-text");
+                titleText.setText(columnQuery.title);
 
 		// Check if Tasks plugin is installed before rendering content
 		if (!this.isTasksPluginInstalled()) {
@@ -814,19 +782,19 @@ export class TaskQueryService {
 		const metadata = taskItem.querySelector(".task-metadata");
 		if (!metadata) return;
 
-		// Add click handler for minimal mode
-		taskItem.addEventListener("mouseenter", () => {
-			if (taskItem.closest(".tasks-styled--minimal")) {
-				(metadata as HTMLElement).style.display = "flex";
-			}
-		});
+                // Add hover handlers for minimal mode
+                taskItem.addEventListener("mouseenter", () => {
+                        if (taskItem.closest(".tasks-styled--minimal")) {
+                                (metadata as HTMLElement).addClass("task-metadata-visible");
+                        }
+                });
 
-		taskItem.addEventListener("mouseleave", () => {
-			if (taskItem.closest(".tasks-styled--minimal")) {
-				(metadata as HTMLElement).style.display = "none";
-			}
-		});
-	}
+                taskItem.addEventListener("mouseleave", () => {
+                        if (taskItem.closest(".tasks-styled--minimal")) {
+                                (metadata as HTMLElement).removeClass("task-metadata-visible");
+                        }
+                });
+        }
 
 	private buildCrossProductQuery(
 		filters: ViewFilters,

--- a/src/settings/task-roles-settings-tab.ts
+++ b/src/settings/task-roles-settings-tab.ts
@@ -22,7 +22,7 @@ export class TaskRolesSettingTab extends PluginSettingTab {
 
 	private createAssigneesSection(containerEl: HTMLElement): void {
 		const section = containerEl.createDiv("task-roles-tabs-container");
-                section.createEl("h4", { text: "Assignees" });
+		section.createEl("h4", { text: "Assignees" });
 		section.createEl("p", {
 			text: "You can assign tasks to people or companies. Each person or company is stored as a note. Customize the directory location and other settings below.",
 		});
@@ -33,8 +33,8 @@ export class TaskRolesSettingTab extends PluginSettingTab {
 		// Active tab state
 		if (!this.activeAssigneesTab) this.activeAssigneesTab = "person";
 
-                // Mark active
-                // Recreate buttons with active styles and click handlers
+		// Mark active
+		// Recreate buttons with active styles and click handlers
 		const personBtn = header.createEl("button", {
 			text: "Person settings",
 			cls: "default-role-tab",
@@ -46,14 +46,14 @@ export class TaskRolesSettingTab extends PluginSettingTab {
 		// Active styles
 		if (this.activeAssigneesTab === "person") {
 			// @ts-ignore
-                        personBtn.addClass?.("is-active");
-                        personBtn.addClass?.("task-roles-btn-active");
-                } else {
-                        // @ts-ignore
-                        companyBtn.addClass?.("is-active");
-                        // @ts-ignore
-                        companyBtn.addClass?.("task-roles-btn-active");
-                }
+			personBtn.addClass?.("is-active");
+			personBtn.addClass?.("task-roles-btn-active");
+		} else {
+			// @ts-ignore
+			companyBtn.addClass?.("is-active");
+			// @ts-ignore
+			companyBtn.addClass?.("task-roles-btn-active");
+		}
 		// Handlers
 		// @ts-ignore
 		personBtn.onclick = () => {
@@ -68,9 +68,9 @@ export class TaskRolesSettingTab extends PluginSettingTab {
 
 		// Details container rendered for active tab only
 		const details = section.createDiv("default-roles-tab-details");
-                if (this.activeAssigneesTab === "person") {
-                        details.createEl("h4", { text: "Person" });
-                        new Setting(details)
+		if (this.activeAssigneesTab === "person") {
+			details.createEl("h4", { text: "Person" });
+			new Setting(details)
 				.setName("Person settings")
 				.setDesc(
 					"A person is anyone you assign a task to. If you already have a directory of contacts, you can use that."
@@ -104,9 +104,9 @@ export class TaskRolesSettingTab extends PluginSettingTab {
 				);
 
 			this.createMePersonFileSetting(details);
-                } else {
-                        details.createEl("h4", { text: "Company" });
-                        new Setting(details)
+		} else {
+			details.createEl("h4", { text: "Company" });
+			new Setting(details)
 				.setName("Company settings")
 				.setDesc(
 					"A company is an organization, team or group you might assign a task to."
@@ -199,15 +199,15 @@ export class TaskRolesSettingTab extends PluginSettingTab {
 			if (isHidden) {
 				// Add a class; real styling handled via CSS
 				// @ts-ignore - addClass exists in Obsidian elements
-                                btn.addClass?.("is-disabled");
-                                btn.addClass?.("task-roles-btn-disabled");
-                        }
-                        if (this.activeDefaultRoleId === role.id) {
-                                // @ts-ignore
-                                btn.addClass?.("is-active");
-                                // @ts-ignore
-                                btn.addClass?.("task-roles-btn-active");
-                        }
+				btn.addClass?.("is-disabled");
+				btn.addClass?.("task-roles-btn-disabled");
+			}
+			if (this.activeDefaultRoleId === role.id) {
+				// @ts-ignore
+				btn.addClass?.("is-active");
+				// @ts-ignore
+				btn.addClass?.("task-roles-btn-active");
+			}
 			// Wire click
 			// @ts-ignore
 			btn.onclick = () => {
@@ -445,9 +445,9 @@ export class TaskRolesSettingTab extends PluginSettingTab {
 	private createCustomRolesSection(containerEl: HTMLElement): void {
 		const section = containerEl.createDiv("task-roles-tabs-container");
 		section.createEl("h4", { text: "Custom roles" });
-                section.createEl("p", {
-                        text: "You can create custom roles to fit your workflow below.",
-                });
+		section.createEl("p", {
+			text: "You can create custom roles to fit your workflow below.",
+		});
 
 		if (!this.activeCustomRolesTab) this.activeCustomRolesTab = "list";
 
@@ -462,14 +462,14 @@ export class TaskRolesSettingTab extends PluginSettingTab {
 		});
 		if (this.activeCustomRolesTab === "list") {
 			// @ts-ignore
-                        listBtn.addClass?.("is-active");
-                        listBtn.addClass?.("task-roles-btn-active");
-                } else {
-                        // @ts-ignore
-                        addBtn.addClass?.("is-active");
-                        // @ts-ignore
-                        addBtn.addClass?.("task-roles-btn-active");
-                }
+			listBtn.addClass?.("is-active");
+			listBtn.addClass?.("task-roles-btn-active");
+		} else {
+			// @ts-ignore
+			addBtn.addClass?.("is-active");
+			// @ts-ignore
+			addBtn.addClass?.("task-roles-btn-active");
+		}
 		// Click handlers
 		// @ts-ignore
 		listBtn.onclick = () => {
@@ -482,12 +482,12 @@ export class TaskRolesSettingTab extends PluginSettingTab {
 			this.display();
 		};
 
-                const details = section.createDiv("default-roles-tab-details");
-                if (this.activeCustomRolesTab === "list") {
-                        details.createEl("h4", { text: "Custom Roles" });
-                        new Setting(details)
-                                .setName("Custom roles")
-                                .setDesc("Custom roles you have created are listed below.");
+		const details = section.createDiv("default-roles-tab-details");
+		if (this.activeCustomRolesTab === "list") {
+			details.createEl("h4", { text: "Custom Roles" });
+			new Setting(details)
+				.setName("Custom roles")
+				.setDesc("Custom roles you have created are listed below.");
 			const defaultIds = new Set(DEFAULT_ROLES.map((r) => r.id));
 			const customRoles = this.plugin.settings.roles.filter(
 				(r) => !defaultIds.has(r.id)
@@ -529,11 +529,11 @@ export class TaskRolesSettingTab extends PluginSettingTab {
 					);
 				}
 			}
-                } else {
-                        details.createEl("h4", { text: "Add New Role" });
-                        new Setting(details)
-                                .setName("Add new role")
-                                .setDesc("Use the form below to create a new custom role.");
+		} else {
+			details.createEl("h4", { text: "Add New Role" });
+			new Setting(details)
+				.setName("Add new role")
+				.setDesc("Use the form below to create a new custom role.");
 			let nameInput: HTMLInputElement;
 			let iconInput: HTMLInputElement;
 			let shortcutInput: HTMLInputElement;

--- a/src/settings/task-roles-settings-tab.ts
+++ b/src/settings/task-roles-settings-tab.ts
@@ -22,7 +22,7 @@ export class TaskRolesSettingTab extends PluginSettingTab {
 
 	private createAssigneesSection(containerEl: HTMLElement): void {
 		const section = containerEl.createDiv("task-roles-tabs-container");
-		section.createEl("h4", { text: "Assigning tasks" });
+                section.createEl("h4", { text: "Assignees" });
 		section.createEl("p", {
 			text: "You can assign tasks to people or companies. Each person or company is stored as a note. Customize the directory location and other settings below.",
 		});
@@ -33,13 +33,8 @@ export class TaskRolesSettingTab extends PluginSettingTab {
 		// Active tab state
 		if (!this.activeAssigneesTab) this.activeAssigneesTab = "person";
 
-		// Mark active
-		// @ts-ignore
-		const headerButtons = (header as any).createEl?.mock ? [] : undefined;
-		// Set class hints
-		// @ts-ignore
-		const headerChildren: any[] = [];
-		// Recreate buttons with active styles and click handlers
+                // Mark active
+                // Recreate buttons with active styles and click handlers
 		const personBtn = header.createEl("button", {
 			text: "Person settings",
 			cls: "default-role-tab",
@@ -51,15 +46,14 @@ export class TaskRolesSettingTab extends PluginSettingTab {
 		// Active styles
 		if (this.activeAssigneesTab === "person") {
 			// @ts-ignore
-			personBtn.addClass?.("is-active");
-			// @ts-ignore
-			personBtn.style && (personBtn.style.fontWeight = "600");
-		} else {
-			// @ts-ignore
-			companyBtn.addClass?.("is-active");
-			// @ts-ignore
-			companyBtn.style && (companyBtn.style.fontWeight = "600");
-		}
+                        personBtn.addClass?.("is-active");
+                        personBtn.addClass?.("task-roles-btn-active");
+                } else {
+                        // @ts-ignore
+                        companyBtn.addClass?.("is-active");
+                        // @ts-ignore
+                        companyBtn.addClass?.("task-roles-btn-active");
+                }
 		// Handlers
 		// @ts-ignore
 		personBtn.onclick = () => {
@@ -74,8 +68,9 @@ export class TaskRolesSettingTab extends PluginSettingTab {
 
 		// Details container rendered for active tab only
 		const details = section.createDiv("default-roles-tab-details");
-		if (this.activeAssigneesTab === "person") {
-			new Setting(details)
+                if (this.activeAssigneesTab === "person") {
+                        details.createEl("h4", { text: "Person" });
+                        new Setting(details)
 				.setName("Person settings")
 				.setDesc(
 					"A person is anyone you assign a task to. If you already have a directory of contacts, you can use that."
@@ -109,8 +104,9 @@ export class TaskRolesSettingTab extends PluginSettingTab {
 				);
 
 			this.createMePersonFileSetting(details);
-		} else {
-			new Setting(details)
+                } else {
+                        details.createEl("h4", { text: "Company" });
+                        new Setting(details)
 				.setName("Company settings")
 				.setDesc(
 					"A company is an organization, team or group you might assign a task to."
@@ -203,17 +199,15 @@ export class TaskRolesSettingTab extends PluginSettingTab {
 			if (isHidden) {
 				// Add a class; real styling handled via CSS
 				// @ts-ignore - addClass exists in Obsidian elements
-				btn.addClass?.("is-disabled");
-				// Fallback style for environments without addClass helpers
-				// @ts-ignore
-				btn.style && (btn.style.opacity = "0.45");
-			}
-			if (this.activeDefaultRoleId === role.id) {
-				// @ts-ignore
-				btn.addClass?.("is-active");
-				// @ts-ignore
-				btn.style && (btn.style.fontWeight = "600");
-			}
+                                btn.addClass?.("is-disabled");
+                                btn.addClass?.("task-roles-btn-disabled");
+                        }
+                        if (this.activeDefaultRoleId === role.id) {
+                                // @ts-ignore
+                                btn.addClass?.("is-active");
+                                // @ts-ignore
+                                btn.addClass?.("task-roles-btn-active");
+                        }
 			// Wire click
 			// @ts-ignore
 			btn.onclick = () => {
@@ -451,9 +445,9 @@ export class TaskRolesSettingTab extends PluginSettingTab {
 	private createCustomRolesSection(containerEl: HTMLElement): void {
 		const section = containerEl.createDiv("task-roles-tabs-container");
 		section.createEl("h4", { text: "Custom roles" });
-		section.createEl("p", {
-			text: "Create custom roles to fit your workflow below.",
-		});
+                section.createEl("p", {
+                        text: "You can create custom roles to fit your workflow below.",
+                });
 
 		if (!this.activeCustomRolesTab) this.activeCustomRolesTab = "list";
 
@@ -468,15 +462,14 @@ export class TaskRolesSettingTab extends PluginSettingTab {
 		});
 		if (this.activeCustomRolesTab === "list") {
 			// @ts-ignore
-			listBtn.addClass?.("is-active");
-			// @ts-ignore
-			listBtn.style && (listBtn.style.fontWeight = "600");
-		} else {
-			// @ts-ignore
-			addBtn.addClass?.("is-active");
-			// @ts-ignore
-			addBtn.style && (addBtn.style.fontWeight = "600");
-		}
+                        listBtn.addClass?.("is-active");
+                        listBtn.addClass?.("task-roles-btn-active");
+                } else {
+                        // @ts-ignore
+                        addBtn.addClass?.("is-active");
+                        // @ts-ignore
+                        addBtn.addClass?.("task-roles-btn-active");
+                }
 		// Click handlers
 		// @ts-ignore
 		listBtn.onclick = () => {
@@ -489,11 +482,12 @@ export class TaskRolesSettingTab extends PluginSettingTab {
 			this.display();
 		};
 
-		const details = section.createDiv("default-roles-tab-details");
-		if (this.activeCustomRolesTab === "list") {
-			new Setting(details)
-				.setName("Custom roles")
-				.setDesc("Custom roles you have created are listed below.");
+                const details = section.createDiv("default-roles-tab-details");
+                if (this.activeCustomRolesTab === "list") {
+                        details.createEl("h4", { text: "Custom Roles" });
+                        new Setting(details)
+                                .setName("Custom roles")
+                                .setDesc("Custom roles you have created are listed below.");
 			const defaultIds = new Set(DEFAULT_ROLES.map((r) => r.id));
 			const customRoles = this.plugin.settings.roles.filter(
 				(r) => !defaultIds.has(r.id)
@@ -535,10 +529,11 @@ export class TaskRolesSettingTab extends PluginSettingTab {
 					);
 				}
 			}
-		} else {
-			new Setting(details)
-				.setName("Add new role")
-				.setDesc("Use the form below to create a new custom role.");
+                } else {
+                        details.createEl("h4", { text: "Add New Role" });
+                        new Setting(details)
+                                .setName("Add new role")
+                                .setDesc("Use the form below to create a new custom role.");
 			let nameInput: HTMLInputElement;
 			let iconInput: HTMLInputElement;
 			let shortcutInput: HTMLInputElement;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -12,6 +12,8 @@ If your plugin does not need CSS, delete this file.
 /* Role Suggestion Dropdown Styles */
 .task-roles-suggestion-dropdown {
     position: fixed;
+    left: var(--task-roles-dropdown-left, 0);
+    top: var(--task-roles-dropdown-top, 0);
     background: var(--background-primary);
     border: 1px solid var(--background-modifier-border);
     border-radius: 8px;
@@ -78,6 +80,34 @@ If your plugin does not need CSS, delete this file.
 
 .settings-shortcut-valid {
     border: "";
+}
+
+.task-roles-btn-active {
+    font-weight: 600;
+}
+
+.task-roles-btn-disabled {
+    opacity: 0.45;
+}
+
+.task-roles-hidden {
+    display: none;
+}
+
+.compact-multiselect-display.has-white-arrow {
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23ffffff' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6,9 12,15 18,9'%3E%3C/polyline%3E%3C/svg%3E");
+}
+
+.overwrite-warning {
+    color: var(--text-warning);
+    margin-top: 8px;
+    font-size: 14px;
+}
+
+.view-name-error {
+    color: var(--text-error);
+    margin-top: 8px;
+    font-size: 14px;
 }
 
 .roles-container {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -482,11 +482,11 @@ If your plugin does not need CSS, delete this file.
     box-shadow: var(--shadow-s);
 }
 
-.task-roles-tabs-container > h4 {
+.task-roles-tabs-container>h4 {
     margin: 0 0 8px 0;
 }
 
-.task-roles-tabs-container > p {
+.task-roles-tabs-container>p {
     margin: 0 0 12px 0;
     color: var(--text-muted);
     font-size: var(--font-ui-small);

--- a/styles/task-roles-view.css
+++ b/styles/task-roles-view.css
@@ -205,7 +205,8 @@
 }
 
 .compact-filter-input-wrapper .compact-filter-input {
-    padding-right: 24px; /* Make room for clear button */
+    padding-right: 24px;
+    /* Make room for clear button */
 }
 
 .compact-filter-clear-btn {
@@ -885,7 +886,7 @@
 
 /* Task content wrapper - positioned below checkbox and priority with better typography */
 .task-query-display .task-list-item .task-description,
-.task-query-display .task-list-item > p {
+.task-query-display .task-list-item>p {
     margin-left: 0 !important;
     margin-top: 22px !important;
     margin-bottom: 0 !important;
@@ -899,7 +900,7 @@
 
 /* Force re-apply for styled items */
 .task-query-display .task-list-item.task-roles-styled .task-description,
-.task-query-display .task-list-item.task-roles-styled > p {
+.task-query-display .task-list-item.task-roles-styled>p {
     margin-left: 0 !important;
     margin-top: 22px !important;
     margin-bottom: 0 !important;
@@ -1128,7 +1129,7 @@
     flex: 1;
 }
 
-.task-roles-column .task-query-display > div {
+.task-roles-column .task-query-display>div {
     height: 100%;
     overflow-y: auto;
     max-height: 100%;

--- a/styles/task-roles-view.css
+++ b/styles/task-roles-view.css
@@ -764,6 +764,9 @@
     font-weight: 600;
     color: var(--text-normal);
     font-size: 14px;
+    display: flex;
+    align-items: center;
+    gap: 0;
 }
 
 .task-roles-column-count {
@@ -1504,4 +1507,77 @@ ul.contains-task-list.plugin-tasks-query-result.tasks-layout-hide-urgency,
     overflow-wrap: break-word;
     max-width: 100%;
     overflow-x: auto;
+}
+
+/* Tasks Plugin Notice */
+.tasks-plugin-notice {
+    padding: 20px;
+    text-align: center;
+    color: var(--text-muted);
+    border: 2px dashed var(--background-modifier-border);
+    border-radius: 8px;
+    margin: 10px 0;
+    background-color: var(--background-secondary);
+}
+
+.tasks-plugin-notice-icon {
+    margin-bottom: 10px;
+}
+
+.tasks-plugin-notice-icon-span {
+    width: 24px;
+    height: 24px;
+    color: var(--text-warning);
+}
+
+.tasks-plugin-notice-text {
+    font-size: 14px;
+    line-height: 1.4;
+}
+
+.tasks-plugin-notice-title {
+    font-weight: bold;
+    margin-bottom: 8px;
+    color: var(--text-normal);
+}
+
+.tasks-plugin-notice-desc {
+    margin-bottom: 12px;
+}
+
+.tasks-plugin-notice-instructions {
+    font-size: 12px;
+    color: var(--text-muted);
+    margin-bottom: 15px;
+}
+
+.tasks-plugin-notice-refresh {
+    margin-top: 10px;
+    padding: 6px 12px;
+}
+
+/* Column header icon styles */
+.column-icon-emoji {
+    margin-right: 8px;
+    font-size: 16px;
+    line-height: 1;
+    vertical-align: middle;
+}
+
+.column-icon {
+    margin-right: 8px;
+    display: inline-flex;
+    align-items: center;
+    vertical-align: middle;
+    width: 16px;
+    height: 16px;
+}
+
+.column-title-text {
+    vertical-align: middle;
+}
+
+/* Metadata visibility */
+.task-metadata-visible {
+    display: flex;
 }

--- a/tests/compact-filters.test.ts
+++ b/tests/compact-filters.test.ts
@@ -169,8 +169,8 @@ describe("CompactFiltersComponent", () => {
 			const clearButton = container.querySelector(
 				".compact-filter-clear-btn"
 			) as HTMLElement;
-			expect(clearButton).toBeTruthy();
-			expect(clearButton.style.display).toBe("block");
+                        expect(clearButton).toBeTruthy();
+                        expect(clearButton.classList.contains("task-roles-hidden")).toBe(false);
 		});
 
 		it("should hide clear button when no assignees are selected", async () => {
@@ -193,8 +193,8 @@ describe("CompactFiltersComponent", () => {
 			const clearButton = container.querySelector(
 				".compact-filter-clear-btn"
 			) as HTMLElement;
-			expect(clearButton).toBeTruthy();
-			expect(clearButton.style.display).toBe("none");
+                        expect(clearButton).toBeTruthy();
+                        expect(clearButton.classList.contains("task-roles-hidden")).toBe(true);
 		});
 
 		it("should clear all assignees when clear button is clicked", async () => {

--- a/tests/compact-filters.test.ts
+++ b/tests/compact-filters.test.ts
@@ -169,8 +169,8 @@ describe("CompactFiltersComponent", () => {
 			const clearButton = container.querySelector(
 				".compact-filter-clear-btn"
 			) as HTMLElement;
-                        expect(clearButton).toBeTruthy();
-                        expect(clearButton.classList.contains("task-roles-hidden")).toBe(false);
+			expect(clearButton).toBeTruthy();
+			expect(clearButton.classList.contains("task-roles-hidden")).toBe(false);
 		});
 
 		it("should hide clear button when no assignees are selected", async () => {
@@ -193,8 +193,8 @@ describe("CompactFiltersComponent", () => {
 			const clearButton = container.querySelector(
 				".compact-filter-clear-btn"
 			) as HTMLElement;
-                        expect(clearButton).toBeTruthy();
-                        expect(clearButton.classList.contains("task-roles-hidden")).toBe(true);
+			expect(clearButton).toBeTruthy();
+			expect(clearButton.classList.contains("task-roles-hidden")).toBe(true);
 		});
 
 		it("should clear all assignees when clear button is clicked", async () => {

--- a/tests/cursor-positioning-wikilink-bug.test.ts
+++ b/tests/cursor-positioning-wikilink-bug.test.ts
@@ -43,17 +43,7 @@ describe("Cursor Positioning Bug - Wikilink Format", () => {
 				}
 			}
 
-			console.log("Line:", line);
-			console.log("Expected closing position:", roleClosingPos);
-			console.log("Actual returned position:", result?.position);
-			console.log(
-				"Character at expected position:",
-				line[roleClosingPos]
-			);
-			console.log(
-				"Character at returned position:",
-				line[result?.position || -1]
-			);
+
 
 			expect(result?.position).toBe(roleClosingPos);
 		});
@@ -111,17 +101,12 @@ describe("Cursor Positioning Bug - Wikilink Format", () => {
 			);
 			const match = dataviewPattern.exec(line);
 
-			console.log("Full match:", match?.[0]);
-			console.log("Captured assignees:", match?.[1]);
 
 			if (match) {
 				const assigneesText = match[1].trim();
 				const hasAssignees = assigneesText.length > 0;
 				const position = match.index + match[0].length - 1;
 
-				console.log("Assignees text:", `"${assigneesText}"`);
-				console.log("Has assignees:", hasAssignees);
-				console.log("Calculated position:", position);
 
 				// The problem is that the regex `[^\\]]*` stops at the first `]`
 				// which is inside the wikilink `[[Task Roles Demo/People/Me|@Me]]`

--- a/tests/role-suggestion-dropdown.test.ts
+++ b/tests/role-suggestion-dropdown.test.ts
@@ -397,11 +397,10 @@ describe("Role Suggestion Dropdown", () => {
 				roleSuggestionDropdown.show(
 					cursor,
 					existingRoles,
-					(role: any) => {
-						// Mock callback for role insertion - this will be captured in tests
-						console.log("Role selected:", role);
-					}
-				);
+                                        (_role: any) => {
+                                                // Mock callback for role insertion - this will be captured in tests
+                                        }
+                                );
 				return { action: "showDropdown" };
 			}
 		};

--- a/tests/role-suggestion-dropdown.test.ts
+++ b/tests/role-suggestion-dropdown.test.ts
@@ -270,15 +270,15 @@ describe("Role Suggestion Dropdown", () => {
 							!mockSettings.hiddenDefaultRoles.includes(role.id)
 					);
 				} else {
-                this.availableRoles = mockSettings.roles.filter(
-                    (role: any) =>
-                        !mockSettings.hiddenDefaultRoles.includes(
-                            role.id
-                        ) &&
-                        ((role.names?.[0] || "")
-                            .toLowerCase()
-                            .startsWith(filter.toLowerCase()))
-                );
+					this.availableRoles = mockSettings.roles.filter(
+						(role: any) =>
+							!mockSettings.hiddenDefaultRoles.includes(
+								role.id
+							) &&
+							((role.names?.[0] || "")
+								.toLowerCase()
+								.startsWith(filter.toLowerCase()))
+					);
 				}
 				// Reset selection if no matches
 				if (this.availableRoles.length === 0) {
@@ -397,10 +397,10 @@ describe("Role Suggestion Dropdown", () => {
 				roleSuggestionDropdown.show(
 					cursor,
 					existingRoles,
-                                        (_role: any) => {
-                                                // Mock callback for role insertion - this will be captured in tests
-                                        }
-                                );
+					(_role: any) => {
+						// Mock callback for role insertion - this will be captured in tests
+					}
+				);
 				return { action: "showDropdown" };
 			}
 		};
@@ -789,11 +789,11 @@ describe("Role Suggestion Dropdown", () => {
 				action: "insertRole",
 				role: DEFAULT_ROLES[0],
 			});
-            // Should use the same role object structure as existing shortcuts
-            expect(result.role).toHaveProperty("id");
-            expect(result.role).toHaveProperty("names");
-            expect(result.role).toHaveProperty("icon");
-        });
+			// Should use the same role object structure as existing shortcuts
+			expect(result.role).toHaveProperty("id");
+			expect(result.role).toHaveProperty("names");
+			expect(result.role).toHaveProperty("icon");
+		});
 	});
 
 	describe("Bug Fixes", () => {

--- a/tests/smart-insertion-points.test.ts
+++ b/tests/smart-insertion-points.test.ts
@@ -129,13 +129,6 @@ describe("Smart Insertion Point Detection", () => {
 				true
 			);
 
-			console.log("Line:", line);
-			console.log("Cursor position:", cursorPos);
-			console.log("Nearest legal position:", nearestPos);
-			console.log(
-				"Character at nearest position:",
-				`"${line[nearestPos]}"`
-			);
 		});
 
 		it("should prefer positions after existing roles", () => {


### PR DESCRIPTION
## Summary
- move task query notice and column styling into CSS classes
- use CSS variables and class toggles instead of inline styles across UI components
- replace console.log usage with debug/info logging

## Testing
- `npm run lint` *(fails: markdown style violations)*
- `npm run lint:ts`
- `npm run test`
- `npm run coverage`


------
https://chatgpt.com/codex/tasks/task_e_68bea88344e883299e8e17cf28775b24